### PR TITLE
Search for .cmd/.bat files even when the executable contains a '.'

### DIFF
--- a/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
@@ -583,28 +583,30 @@ public class ExecMojo
                 if ( OS.isFamilyWindows() )
                 {
                     List<String> paths = this.getExecutablePaths( enviro );
-                    for ( String extension : WINDOWS_SPECIAL_EXTS )
-                    {
-                        String ex = !executable.contains( "." ) ? executable + extension : executable;
-                        File f = new File( dir, ex );
+                    paths.add( 0, dir.getAbsolutePath() );
+
+                    File f = null;
+                    for ( String path : paths ) {
+                        f = new File( path, executable );
                         if ( f.isFile() )
                         {
-                            exec = ex;
+                            break;
                         }
-
-                        if ( exec == null )
+                        else
                         {
-                            for ( String elem : paths )
+                            for ( String extension : WINDOWS_SPECIAL_EXTS )
                             {
-                                f = new File( new File( elem ), ex );
+                                f = new File(path, executable + extension);
                                 if ( f.isFile() )
                                 {
-                                    exec = ex;
                                     break;
                                 }
                             }
                         }
+                    }
 
+                    if ( f != null ) {
+                        exec = f.getAbsolutePath();
                     }
                 }
             }


### PR DESCRIPTION
Fixes #24 


----

Note that the search order now changed, from what I can see the plugin doesn't specify that. Assume `PATH` contains `a:b`, executable is `exe`, and these files exist:

 * `a\exe.cmd`
 * `b\exe.bat`

The previous behavior was to do the path search inside the loop with the extension, so it would find `b\exe.bat`. The code in caec112 changes that to first scan the directories, and so it finds `a\exe.cmd`. This could be changed if needed of course.