### PR TITLE
Supports custom toolchains

### DIFF
--- a/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
@@ -102,6 +102,14 @@ public class ExecMojo
     private String executable;
 
     /**
+     * <p>
+     * The toolchain. If omitted, <code>"jdk"</code> is assumed.
+     * </p>
+     */
+    @Parameter( property = "exec.toolchain", defaultValue = "jdk")
+    private String toolchain;
+    
+    /**
      * The current working directory. Optional. If not specified, basedir will be used.
      *
      * @since 1.0
@@ -810,7 +818,7 @@ public class ExecMojo
 
                 if ( toolchainManager != null )
                 {
-                    tc = toolchainManager.getToolchainFromBuildContext( "jdk", session );
+                    tc = toolchainManager.getToolchainFromBuildContext( toolchain, session );
                 }
             }
         }


### PR DESCRIPTION
New optional <toolchain> configuration option allows to utiliz other toolchains than "jdk".

This makes it pretty easy to get rid of PATH modifications for using non-JDK tools.

Exemplary use case: Invoke "WinWord.exe" to convert .docx user documentation source code into .pdf end user distribution files.