### PR TITLE
Fully functional Toolchains support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,16 @@
         <role>Patch Contributor</role>
       </roles>
     </contributor>
+    <contributor>
+      <name>Markus KARG</name>
+      <email>markus@headcrashing.eu</email>
+      <organization>Head Crashing Informatics</organization>
+      <organizationUrl>http://www.headcrashing.eu</organizationUrl>
+      <roles>
+        <role>Patch Contributor</role>
+      </roles>
+      <timezone>Europe/Berlin</timezone>
+    </contributor>
   </contributors>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-component-annotations</artifactId>
+      <version>1.6</version>
+      <scope>provided</scope>
+	</dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-exec</artifactId>
       <version>1.3</version>
@@ -218,6 +225,18 @@
             <version>1.0</version>
           </signature>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-component-metadata</artifactId>
+        <version>1.6</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate-metadata</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/org/codehaus/mojo/exec/PathsToolchain.java
+++ b/src/main/java/org/codehaus/mojo/exec/PathsToolchain.java
@@ -1,0 +1,70 @@
+package org.codehaus.mojo.exec;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.util.List;
+
+import org.apache.maven.toolchain.DefaultToolchain;
+import org.apache.maven.toolchain.model.ToolchainModel;
+import org.codehaus.plexus.logging.Logger;
+import org.codehaus.plexus.util.Os;
+
+/**
+ * Searches a list of configured paths for the requested tool.
+ *
+ * @author Markus KARG (markus@headcrashing.eu)
+ */
+class PathsToolchain extends DefaultToolchain {
+	private List<String> paths;
+
+	public PathsToolchain(final ToolchainModel model, final Logger logger) {
+		super(model, "paths", logger); // NOI18N
+	}
+
+	public List<String> getPaths() {
+		return this.paths;
+	}
+
+	public void setPaths(final List<String> paths) {
+		this.paths = paths;
+	}
+
+	@Override
+	public String toString() {
+		return "Paths" + this.getPaths(); // NOI18N
+	}
+
+	public String findTool(final String toolName) {
+		for (final String path : this.paths) {
+			final File tool = findTool(toolName, new File(path));
+			if (tool != null)
+				return tool.getAbsolutePath();
+		}
+
+		return null;
+	}
+
+	private static File findTool(final String toolName, final File folder) {
+		final File tool = new File(folder, toolName + (Os.isFamily("windows") && !toolName.contains(".") ? ".exe" : "")); // NOI18N
+
+		return tool.exists() ? tool : null;
+	}
+}

--- a/src/main/java/org/codehaus/mojo/exec/PathsToolchainFactory.java
+++ b/src/main/java/org/codehaus/mojo/exec/PathsToolchainFactory.java
@@ -1,0 +1,139 @@
+package org.codehaus.mojo.exec;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.beans.IntrospectionException;
+import java.beans.PropertyDescriptor;
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.maven.toolchain.MisconfiguredToolchainException;
+import org.apache.maven.toolchain.RequirementMatcherFactory;
+import org.apache.maven.toolchain.ToolchainFactory;
+import org.apache.maven.toolchain.ToolchainPrivate;
+import org.apache.maven.toolchain.model.ToolchainModel;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.codehaus.plexus.logging.Logger;
+import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+
+/**
+ * Factory for {@link PathsToolchain}.
+ *
+ * @author Markus KARG (markus@headcrashing.eu)
+ */
+@Component(role = ToolchainFactory.class, hint = "paths")
+class PathsToolchainFactory implements ToolchainFactory {
+
+	@Requirement
+	private Logger logger;
+
+	public ToolchainPrivate createToolchain(final ToolchainModel model) throws MisconfiguredToolchainException {
+		if (model == null)
+			return null;
+
+		final PathsToolchain pathsToolchain = new PathsToolchain(model, this.logger);
+		final Properties provides = this.getProvidesProperties(model);
+		for (final Map.Entry<Object, Object> provide : provides.entrySet()) {
+			final String key = (String) provide.getKey();
+			final String value = (String) provide.getValue();
+			if (value == null)
+				throw new MisconfiguredToolchainException("Provides token '" + key + "' doesn't have any value configured.");
+
+			pathsToolchain.addProvideToken(key, RequirementMatcherFactory.createExactMatcher(value));
+		}
+
+		final Xpp3Dom config = (Xpp3Dom) model.getConfiguration();
+		if (config == null)
+			return pathsToolchain;
+
+		final Xpp3Dom pathDom = config.getChild("paths");
+		if (pathDom == null)
+			return pathsToolchain;
+
+		final Xpp3Dom[] pathDoms = pathDom.getChildren("path");
+		if (pathDoms == null || pathDoms.length == 0)
+			return pathsToolchain;
+
+		final List<String> paths = new ArrayList<String>(pathDoms.length);
+		for (final Xpp3Dom pathdom : pathDoms) {
+			final String pathString = pathdom.getValue();
+
+			if (pathString == null)
+				throw new MisconfiguredToolchainException("path element is empty");
+
+			final String normalizedPath = FileUtils.normalize(pathString);
+			final File file = new File(normalizedPath);
+			if (!file.exists())
+				throw new MisconfiguredToolchainException("Non-existing path '" + file.getAbsolutePath() + "'");
+
+			paths.add(normalizedPath);
+		}
+
+		pathsToolchain.setPaths(paths);
+
+		return pathsToolchain;
+	}
+
+	public ToolchainPrivate createDefaultToolchain() {
+		return null;
+	}
+
+	protected Properties getProvidesProperties(final ToolchainModel model) {
+		final Object value = this.getBeanProperty(model, "provides");
+
+		return value instanceof Properties ? (Properties) value : toProperties((Xpp3Dom) value);
+	}
+
+	protected static Properties toProperties(final Xpp3Dom dom) {
+		final Properties props = new Properties();
+
+		final Xpp3Dom[] children = dom.getChildren();
+		for (final Xpp3Dom child : children)
+			props.put(child.getName(), child.getValue());
+
+		return props;
+	}
+
+	protected Object getBeanProperty(final Object obj, final String property) {
+		try {
+			final Method method = new PropertyDescriptor(property, obj.getClass()).getReadMethod();
+
+			return method.invoke(obj);
+		} catch (final IntrospectionException e) {
+			throw new RuntimeException("Incompatible toolchain API", e);
+		} catch (final IllegalAccessException e) {
+			throw new RuntimeException("Incompatible toolchain API", e);
+		} catch (final InvocationTargetException e) {
+			final Throwable cause = e.getCause();
+
+			if (cause instanceof RuntimeException)
+				throw (RuntimeException) cause;
+
+			throw new RuntimeException("Incompatible toolchain API", e);
+		}
+	}
+}

--- a/src/site/apt/examples/example-exec-using-toolchains.apt.vm
+++ b/src/site/apt/examples/example-exec-using-toolchains.apt.vm
@@ -1,0 +1,166 @@
+ ------
+ Using toolchains with the exec:exec goal
+ ------
+ Markus KARG 
+ ------
+ 2016-04-24
+ ------
+
+ ~~ Copyright 2016 The Codehaus
+ ~~
+ ~~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~~ you may not use this file except in compliance with the License.
+ ~~ You may obtain a copy of the License at
+ ~~
+ ~~      http://www.apache.org/licenses/LICENSE-2.0
+ ~~
+ ~~ Unless required by applicable law or agreed to in writing, software
+ ~~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~~ See the License for the specific language governing permissions and
+ ~~ limitations under the License.
+
+ ~~ NOTE: For help with the syntax of this file, see:
+ ~~ http://maven.apache.org/doxia/references/apt-format.html
+
+
+Using Toolchains Instead of Explicit Paths
+
+  To keep both, the POM and the <<<PATH>>> free of explicit paths, the <<<exec:exec>>> goal supports Maven Toolchains.
+  Toolchains are configured using the file <<<toolchains.xml>>> and apply different algorithms how to find the wanted tool on disk.
+  More information on toolchains can be found on the {{{https://maven.apache.org/guides/mini/guide-using-toolchains.html}Maven web site}}.
+  
+  There are two ways of using toolchains: The "jdk" toolchain provided by the Maven Toolchains Plugin, and custom toolchains provided by third party plugins.
+
+* The "jdk" Toolchain
+
+  The "jdk" toolchain is included in the Maven Toolchains Plugin and enabled by default.
+  It searches the <<<bin>>> folder of the specified JDK for the requested tool.
+
+** pom.xml
+
+-------------------
+<project>
+  ...
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-toolchains-plugin</artifactId>
+        <version>1.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>toolchain</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <toolchains>
+            <jdk>
+              <!-- Select the JDK to be searched --> 
+              <version>[1.5,)</version>
+            </jdk>
+          </toolchains>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>${project.version}</version>
+        ...
+      </plugin>
+    </plugins>
+  </build>
+  ...
+</project>
+-------------------
+
+** toolchains.xml
+
+-------------------
+<?xml version="1.0" encoding="UTF8"?>
+<toolchains>
+  <toolchain>
+    <type>jdk</type>
+    <provides>
+      <!-- Defines the root folder of the "sun-jdk-1.5" JDK -->
+      <version>1.5</version>
+      <vendor>sun</vendor>
+      <id>sun-jdk-1.5</id>
+    </provides>
+    <configuration>
+      <jdkHome>C:\Program Files\Java\jdk1.5.0</jdkHome>
+    </configuration>
+  </toolchain>
+  ...
+</toolchains>
+-------------------
+
+* Custom Toolchains
+
+  Custom toolchains are included in third party Maven plugins and must be enabled explicitly in the POM.
+  Their type id, configuration and search algorithms are plugin specific.
+  See particular plugin's documentation.
+
+** pom.xml
+
+-------------------
+<project>
+  ...
+  <build>
+    <extensions>
+      <extension>
+        <!-- plugin's GAV coordinates go here -->
+      </extension>
+    </extensions>
+    ...
+    <plugins>
+      <plugin>
+        <artifactId>maven-toolchains-plugin</artifactId>
+        <version>1.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>toolchain</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <toolchains>
+            <!-- toolchain-specific selector goes here -->
+          </toolchains>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>${project.version}</version>
+        ...
+        <configuration>
+          <toolchain><!-- toolchain's type id goes here --></toolchain>
+        </configuration>
+        ...
+      </plugin>
+    </plugins>
+  </build>
+  ...
+</project>
+-------------------
+
+** toolchains.xml
+
+-------------------
+<?xml version="1.0" encoding="UTF8"?>
+<toolchains>
+  <toolchain>
+    <type><!-- toolchain's type id goes here --></type>
+    <provides>
+      <!-- toolchain-specific provision goes here -->
+    </provides>
+    <configuration>
+      <!-- toolchain-specific configuration goes here -->
+    </configuration>
+  </toolchain>
+  ...
+</toolchains>
+-------------------

--- a/src/site/apt/examples/example-exec-using-toolchains.apt.vm
+++ b/src/site/apt/examples/example-exec-using-toolchains.apt.vm
@@ -30,7 +30,79 @@ Using Toolchains Instead of Explicit Paths
   Toolchains are configured using the file <<<toolchains.xml>>> and apply different algorithms how to find the wanted tool on disk.
   More information on toolchains can be found on the {{{https://maven.apache.org/guides/mini/guide-using-toolchains.html}Maven web site}}.
   
-  There are two ways of using toolchains: The "jdk" toolchain provided by the Maven Toolchains Plugin, and custom toolchains provided by third party plugins.
+  There are three ways of using toolchains: The "paths" toolchain provided by the Exec Maven Plugin, the "jdk" toolchain provided by the Maven Toolchains Plugin, and custom toolchains provided by third party plugins.
+  
+* The "paths" Toolchain
+
+  The "paths" toolchain is included in the Exec Maven Plugin and must be enabled explicitly in the POM.
+  It searches a configurable list of folders for the requested tool.
+  The first match will be invoked.
+
+** pom.xml
+
+-------------------
+<project>
+  ...
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-toolchains-plugin</artifactId>
+        <version>1.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>toolchain</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <toolchains>
+            <paths>
+              <!-- Select the "foo-bar" Paths Toolchain Configuration -->
+              <id>foo-bar</id>
+            </paths>
+          </toolchains>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>${project.version}</version>
+        <!-- Enable "paths" Toolchain provided by Exec Maven Plugin -->
+        <extensions>true</extensions>
+        ...
+        <configuration>
+          <toolchain>paths</toolchain>
+        </configuration>
+        ...
+      </plugin>
+    </plugins>
+  </build>
+  ...
+</project>
+-------------------
+
+** toolchains.xml
+
+-------------------
+<?xml version="1.0" encoding="UTF8"?>
+<toolchains>
+  <toolchain>
+    <type>paths</type>
+    <provides>
+      <!-- Defines the folders to search for binaries of the "foo-bar" toolset -->
+      <id>foo-bar</id>
+    </provides>
+    <configuration>
+      <paths>
+        <path>C:\Program Files\FooBar\SDK\bin</path>
+        <path>C:\Program Files\FooBar\Runtime\bin</path>
+      </paths>
+    </configuration>
+  </toolchain>
+  ...
+</toolchains>
+-------------------
 
 * The "jdk" Toolchain
 

--- a/src/site/apt/index.apt
+++ b/src/site/apt/index.apt
@@ -62,3 +62,5 @@ Exec Maven Plugin
   * {{{./examples/example-exec-or-java-change-classpath-scope.html} Changing the classpath scope when running Java programs}}
 
   * {{{./examples/example-exec-using-plugin-dependencies.html} Using plugin dependencies with exec:exec}}
+
+  * {{{./examples/example-exec-using-toolchains.html} Using toolchains instead of explicit paths}}

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -12,6 +12,7 @@
       <item name="Running Java programs with exec:exec" href="examples/example-exec-for-java-programs.html"/>
       <item name="Changing the classpath scope when running Java programs" href="examples/example-exec-or-java-change-classpath-scope.html"/>
       <item name="Using plugin dependencies with exec:exec" href="examples/example-exec-using-plugin-dependencies.html"/>
+      <item name="Using toolchains with exec:exec" href="examples/example-exec-using-toolchains.html"/>
     </menu>
   </body>
 </project>


### PR DESCRIPTION
Toolchains support was rather limited before this pull request: A good documentation was missing, and one had to write his own toolchain plugin for each kind of non-JDK tool.

This pull request solves this gap as it provides two essential patches:
* Three complete examples document how to use toolchains with "jdk" toolchain, custom toolchains, and an newly included fully-configurable toolchain.
* Exec Maven Plugin now includes an internal, fully configurable "paths" toolchain which searches an unlimited, fully configurable list of folders for the requested tool. Due to its flexibility, it is a perfect fit for the exec plugin, as it does to toolchains what the exec plugin does to product-specific plugins: It obsoletes the need to write them.