### PR TITLE
ComSpec support on Windows

### DIFF
--- a/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
@@ -649,7 +649,8 @@ public class ExecMojo
             || OS.isFamilyWindows() && exec.toLowerCase( Locale.getDefault() ).endsWith( ".cmd" ) )
         {
             // run the windows batch script in isolation and exit at the end
-            toRet = new CommandLine( "cmd" );
+            final String comSpec = System.getenv( "ComSpec" );
+            toRet = new CommandLine( comSpec == null ? "cmd" : comSpec );
             toRet.addArgument( "/c" );
             toRet.addArgument( exec );
         }


### PR DESCRIPTION
Uses `ComSpec` on Windows when provided (which is the default on virtually _any_ Windows host), as the batch processor _not necessarily_ is called `com` on that OS family.

See [Microsoft TechNet](https://technet.microsoft.com/en-us/library/cc976142.aspx).