### PR TITLE
Bug Fix: Must not try more paths in case special extension matches

### DIFF
--- a/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
@@ -613,7 +613,7 @@ public class ExecMojo
                     paths.add( 0, dir.getAbsolutePath() );
 
                     File f = null;
-                    for ( String path : paths ) {
+                    search: for ( String path : paths ) {
                         f = new File( path, executable );
                         if ( f.isFile() )
                         {
@@ -626,7 +626,7 @@ public class ExecMojo
                                 f = new File(path, executable + extension);
                                 if ( f.isFile() )
                                 {
-                                    break;
+                                    break search;
                                 }
                             }
                         }


### PR DESCRIPTION
When the special extension matches, the code must leave outer loop, as
an executable file was found. The bug was that just the inner loop was
left, hence the next path was searched, which makes no sense at all.