### PR TITLE
Bug Fix: Misleading error message in case executable is not found

### DIFF
--- a/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
@@ -635,6 +635,10 @@ public class ExecMojo
                     if ( f != null ) {
                         exec = f.getAbsolutePath();
                     }
+
+                    if ( !f.exists() ) {
+                        exec = null;
+                    }
                 }
             }
         }


### PR DESCRIPTION
In case the executable is not found, a misleading message says that "C:\Program" is not an executable file. This is weird, as nobody asked Exec Maven Plugin to execute "C:\Program". This fix correctly says that "C:\FooBar.exe" is not an executable.