### PR TITLE
Uses PATHEXP with toolchains

### DIFF
--- a/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
@@ -609,36 +609,7 @@ public class ExecMojo
                     List<String> paths = this.getExecutablePaths( enviro );
                     paths.add( 0, dir.getAbsolutePath() );
 
-                    File f = null;
-                    search: for ( String path : paths )
-                    {
-                        f = new File( path, executable );
-                        if ( f.isFile() )
-                        {
-                            break;
-                        }
-                        else
-                        {
-                            for ( String extension : getExecutableExtensions() )
-                            {
-                                f = new File( path, executable + extension );
-                                if ( f.isFile() )
-                                {
-                                    break search;
-                                }
-                            }
-                        }
-                    }
-
-                    if ( f != null )
-                    {
-                        exec = f.getAbsolutePath();
-                    }
-
-                    if ( !f.exists() )
-                    {
-                        exec = null;
-                    }
+                    exec = findExecutable( executable, paths );
                 }
             }
         }
@@ -663,6 +634,29 @@ public class ExecMojo
         }
 
         return toRet;
+    }
+
+    static String findExecutable( final String executable, final List<String> paths )
+    {
+        File f = null;
+        search: for ( final String path : paths )
+        {
+            f = new File( path, executable );
+            if ( f.isFile() )
+                break;
+            else
+                for ( final String extension : getExecutableExtensions() )
+                {
+                    f = new File( path, executable + extension );
+                    if ( f.isFile() )
+                        break search;
+                }
+        }
+
+        if ( f == null || !f.exists() )
+            return null;
+
+        return f.getAbsolutePath();
     }
 
     private static boolean hasNativeExtension( final String exec )

--- a/src/main/java/org/codehaus/mojo/exec/PathsToolchain.java
+++ b/src/main/java/org/codehaus/mojo/exec/PathsToolchain.java
@@ -19,13 +19,11 @@ package org.codehaus.mojo.exec;
  * under the License.
  */
 
-import java.io.File;
 import java.util.List;
 
 import org.apache.maven.toolchain.DefaultToolchain;
 import org.apache.maven.toolchain.model.ToolchainModel;
 import org.codehaus.plexus.logging.Logger;
-import org.codehaus.plexus.util.Os;
 
 /**
  * Searches a list of configured paths for the requested tool.
@@ -60,21 +58,6 @@ class PathsToolchain
 
     public String findTool( final String toolName )
     {
-        for ( final String path : this.paths )
-        {
-            final File tool = findTool( toolName, new File( path ) );
-            if ( tool != null )
-                return tool.getAbsolutePath();
-        }
-
-        return null;
-    }
-
-    private static File findTool( final String toolName, final File folder )
-    {
-        final File tool =
-            new File( folder, toolName + ( Os.isFamily( "windows" ) && !toolName.contains( "." ) ? ".exe" : "" ) ); // NOI18N
-
-        return tool.exists() ? tool : null;
+        return ExecMojo.findExecutable( toolName, this.paths );
     }
 }


### PR DESCRIPTION
Previous to this commit, toolchains search used a primitive search algorithm, effectively preventing invocation of anything but .exe / .com files.

**This commit enables toolchains to use the exact same algorithm of PATH-based search.**