### PR TITLE
Search for exact filename only if executable contains a '.' 

### DIFF
--- a/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
@@ -612,20 +612,20 @@ public class ExecMojo
                     File f = null;
                     search: for ( String path : paths )
                     {
-                        f = new File( path, executable );
-                        if ( f.isFile() )
+                        if (executable.contains(".")) 
                         {
-                            break;
+                            f = new File( path, executable );
+                            if ( f.isFile() )
+                            { 
+                                break;
+                            }
                         }
-                        else
+                        for ( String extension : getExecutableExtensions() )
                         {
-                            for ( String extension : getExecutableExtensions() )
+                            f = new File( path, executable + extension );
+                            if ( f.isFile() )
                             {
-                                f = new File( path, executable + extension );
-                                if ( f.isFile() )
-                                {
-                                    break search;
-                                }
+                                break search;
                             }
                         }
                     }

--- a/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
@@ -641,11 +641,11 @@ public class ExecMojo
         File f = null;
         search: for ( final String path : paths )
         {
-            if (executable.contains(".")) 
+            if (executable.contains("."))
             {
                 f = new File( path, executable );
                 if ( f.isFile() )
-                { 
+                {
                     break;
                 }
             }

--- a/src/test/java/org/codehaus/mojo/exec/ExecMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/exec/ExecMojoTest.java
@@ -304,8 +304,16 @@ public class ExecMojoTest
             assertTrue( "is bat file on windows' PATH, execute using ComSpec.", cmd.getExecutable().equals( comSpec ) );
             f.delete();
             assertFalse( "file deleted...", f.exists() );
+            
+            // ISSUE-42
+            String executableInPath = "javax";
+            realMojo.setExecutable(executableInPath);
+            cmd = realMojo.getExecutablePath( enviro, workdir );
+            assertTrue( "file without extension is supposed in PATH", executableInPath.equals(cmd.getExecutable()));
+            
         }
     }
+    
 
     public void testRunFailure()
     {


### PR DESCRIPTION
This PR is a fix for issue #42 due to commit [caec11231e0c3a2e9ee9ed5a40e0e2ccbc831795](https://github.com/mojohaus/exec-maven-plugin/commit/caec11231e0c3a2e9ee9ed5a40e0e2ccbc831795#diff-c835a6e13547a5cbc62133e3801f7920)

Now, a file without a '.' cannot be considered as a possible executable. The 
The behaviour is still not the same as version 1.4.0 but this should be a problem.