### PR TITLE
exec mojo can run executableDependency instead of executable

### DIFF
--- a/src/main/java/org/codehaus/mojo/exec/ExecJavaMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecJavaMojo.java
@@ -151,19 +151,6 @@ public class ExecJavaMojo
     private boolean includePluginDependencies;
 
     /**
-     * If provided the ExecutableDependency identifies which of the plugin dependencies contains the executable class.
-     * This will have the affect of only including plugin dependencies required by the identified ExecutableDependency.
-     * <p/>
-     * If includeProjectDependencies is set to <code>true</code>, all of the project dependencies will be included on
-     * the executable's classpath. Whether a particular project dependency is a dependency of the identified
-     * ExecutableDependency will be irrelevant to its inclusion in the classpath.
-     * 
-     * @since 1.1-beta-1
-     */
-    @Parameter
-    private ExecutableDependency executableDependency;
-
-    /**
      * Whether to interrupt/join and possibly stop the daemon threads upon quitting. <br/>
      * If this is <code>false</code>, maven does nothing about the daemon threads. When maven has no more work to do,
      * the VM will normally terminate any remaining daemon threads.
@@ -678,36 +665,6 @@ public class ExecJavaMojo
         return this.artifactFactory.createBuildArtifact( executableArtifact.getGroupId(),
                                                          executableArtifact.getArtifactId(),
                                                          executableArtifact.getVersion(), "pom" );
-    }
-
-    /**
-     * Examine the plugin dependencies to find the executable artifact.
-     * 
-     * @return an artifact which refers to the actual executable tool (not a POM)
-     * @throws MojoExecutionException if no executable artifact was found
-     */
-    private Artifact findExecutableArtifact()
-        throws MojoExecutionException
-    {
-        // ILimitedArtifactIdentifier execToolAssembly = this.getExecutableToolAssembly();
-
-        Artifact executableTool = null;
-        for ( Artifact pluginDep : this.pluginDependencies )
-        {
-            if ( this.executableDependency.matches( pluginDep ) )
-            {
-                executableTool = pluginDep;
-                break;
-            }
-        }
-
-        if ( executableTool == null )
-        {
-            throw new MojoExecutionException( "No dependency of the plugin matches the specified executableDependency."
-                + "  Specified executableToolAssembly is: " + executableDependency.toString() );
-        }
-
-        return executableTool;
     }
 
     /**

--- a/src/site/apt/examples/example-exec-using-executabledependency.apt.vm
+++ b/src/site/apt/examples/example-exec-using-executabledependency.apt.vm
@@ -1,0 +1,74 @@
+ ------
+ Using executable binary dependencies with the exec:exec goal
+ ------
+ Markus KARG 
+ ------
+ 2016-05-23
+ ------
+
+ ~~ Copyright 2016 The Codehaus
+ ~~
+ ~~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~~ you may not use this file except in compliance with the License.
+ ~~ You may obtain a copy of the License at
+ ~~
+ ~~      http://www.apache.org/licenses/LICENSE-2.0
+ ~~
+ ~~ Unless required by applicable law or agreed to in writing, software
+ ~~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~~ See the License for the specific language governing permissions and
+ ~~ limitations under the License.
+
+ ~~ NOTE: For help with the syntax of this file, see:
+ ~~ http://maven.apache.org/doxia/references/apt-format.html
+
+
+Using Executable Binary Dependencies Instead of Local Executables
+
+  Instead of invoking a locally installed binary executable (identified by <<<executable>>>), a dependency (identified by <<<executableDependency>>>) can directly get executed instead.
+  This particularly is useful when the dependency is an executable binary like <<<.exe>>> or <<<.bat>>> file produced by a different Maven project which got deployed into a repository.
+  The binary gets pulled to the local repository and is getting executed <<right there>> without the need to know its actual file name or location on disk: Just the GA coordinates (<<<groupId>>>, <<<artifactId>>>) are needed.
+  Hence the <<<executable>>> parameter has to be omitted in favor of the <<<executableDependency>>> parameter.
+
+  There are two ways of using executable binary dependencies: Project dependencies and plugin dependencies. Currently the <<<exec>>> goal only supports plugin dependencies.
+
+* Plugin Dependencies
+
+  Plugin Dependencies are referenced from within the plugin configuration.
+
+** pom.xml
+
+-------------------
+<project>
+  ...
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>${project.version}</version>
+        ...
+        <configuration>
+          <executableDependency>
+            <!-- REFERENCES plugin dependency, see declaration below -->
+            <groupId>your-group</groupId>
+            <artifactId>your-artifact</artifactId>
+          </executableDependency>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <!-- DECLARES plugin dependency, see reference above -->
+            <groupId>your-group</groupId>
+            <artifactId>your-artifact</artifactId>
+            <type>exe</type>
+            <version>your-version</version>
+          </dependency>
+        </dependencies>    
+        ...
+      </plugin>
+    </plugins>
+  </build>
+  ...
+</project>
+-------------------

--- a/src/site/apt/index.apt
+++ b/src/site/apt/index.apt
@@ -64,3 +64,5 @@ Exec Maven Plugin
   * {{{./examples/example-exec-using-plugin-dependencies.html} Using plugin dependencies with exec:exec}}
 
   * {{{./examples/example-exec-using-toolchains.html} Using toolchains instead of explicit paths}}
+  
+  * {{{./examples/example-exec-using-executabledependency.html} Using executable binary dependencies instead of local executables}}

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -13,6 +13,7 @@
       <item name="Changing the classpath scope when running Java programs" href="examples/example-exec-or-java-change-classpath-scope.html"/>
       <item name="Using plugin dependencies with exec:exec" href="examples/example-exec-using-plugin-dependencies.html"/>
       <item name="Using toolchains with exec:exec" href="examples/example-exec-using-toolchains.html"/>
+      <item name="Using executable binary dependencies instead of local executables" href="examples/example-exec-using-executabledependency.html"/>
     </menu>
   </body>
 </project>


### PR DESCRIPTION
This PR allows to declare **executableDependency** with the exec:_exec_ goal (just as it was possible already with the exec:_java_ goal). This cool new feature is useful in case one wants to execute a native binary executable (.exe, .bat, etc.) _hosted by a Maven repository_: No need to download and install manually, no need to know the exact file name or location on disk -- just provide the Maven coordinates makes this possible now.