### PR TITLE
fixed #42, Execution of Windows executables broken in 1.5.0

### DIFF
--- a/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
@@ -663,15 +663,14 @@ public class ExecMojo
         search: for ( final String path : paths )
         {
             f = new File( path, executable );
+            for ( final String extension : getExecutableExtensions() )
+            {
+                f = new File( path, executable + extension );
+                if ( f.isFile() )
+                    break search;
+            }
             if ( f.isFile() )
-                break;
-            else
-                for ( final String extension : getExecutableExtensions() )
-                {
-                    f = new File( path, executable + extension );
-                    if ( f.isFile() )
-                        break search;
-                }
+              break;
         }
 
         if ( f == null || !f.exists() )

--- a/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
@@ -663,14 +663,15 @@ public class ExecMojo
         search: for ( final String path : paths )
         {
             f = new File( path, executable );
-            for ( final String extension : getExecutableExtensions() )
-            {
-                f = new File( path, executable + extension );
-                if ( f.isFile() )
-                    break search;
-            }
-            if ( f.isFile() )
-              break;
+            if ( !OS.isFamilyWindows() && f.isFile() )
+                break;
+            else
+                for ( final String extension : getExecutableExtensions() )
+                {
+                    f = new File( path, executable + extension );
+                    if ( f.isFile() )
+                        break search;
+                }
         }
 
         if ( f == null || !f.exists() )

--- a/src/test/java/org/codehaus/mojo/exec/ExecMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/exec/ExecMojoTest.java
@@ -317,7 +317,10 @@ public class ExecMojoTest
     public void testGetExecutablePathPreferExecutableExtensionsOnWindows()
     		throws IOException
     {
-    	Assume.assumeTrue(OS.isFamilyWindows());
+    	// this test is for Windows
+    	if (!OS.isFamilyWindows()) {
+    		return;
+    	}
     	final ExecMojo realMojo = new ExecMojo();
     	
     	final String tmp = System.getProperty("java.io.tmpdir");


### PR DESCRIPTION
Under Windows thoe mojo should prefer windows-specific executable (suffixed with .cmd, .bat) over files without suffix. 
In this special case we had to execute "npm install" and since 1.5.0 the lookup returned "npm" (the linux script) instead of "node.cmd", which is located in the same folder.