### PR TITLE
Unwrap the InvocationTargetException improving the error message

### DIFF
--- a/src/main/java/org/codehaus/mojo/exec/ExecJavaMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecJavaMojo.java
@@ -20,6 +20,7 @@ package org.codehaus.mojo.exec;
  */
 
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.net.MalformedURLException;
@@ -285,6 +286,11 @@ public class ExecJavaMojo
                     Thread.currentThread().getThreadGroup().uncaughtException( Thread.currentThread(),
                                                                                new Exception( "The specified mainClass doesn't contain a main method with appropriate signature.",
                                                                                               e ) );
+                }
+                catch ( InvocationTargetException e )
+                { // use the cause if available to improve the plugin execution output
+                   Throwable exceptionToReport = e.getCause() != null ? e.getCause() : e;
+                   Thread.currentThread().getThreadGroup().uncaughtException( Thread.currentThread(), exceptionToReport );
                 }
                 catch ( Exception e )
                 { // just pass it on

--- a/src/test/java/org/codehaus/mojo/exec/ExecJavaMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/exec/ExecJavaMojoTest.java
@@ -17,6 +17,7 @@ package org.codehaus.mojo.exec;
  */
 
 import java.io.File;
+import java.io.IOException;
 import java.io.PrintStream;
 
 import org.apache.maven.artifact.repository.ArtifactRepository;
@@ -24,6 +25,7 @@ import org.apache.maven.artifact.repository.DefaultArtifactRepository;
 import org.apache.maven.artifact.repository.layout.ArtifactRepositoryLayout;
 import org.apache.maven.monitor.logging.DefaultLog;
 import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectBuilder;
@@ -76,6 +78,33 @@ public class ExecJavaMojoTest
         execute( pom, "java" );
 
         assertEquals( "System property now empty", "", System.getProperty( "project5.property.with.no.value" ) );
+    }
+
+    /**
+     * Check that an execution that throws propagates the cause of the failure into the output
+     * and correctly unwraps the InvocationTargetException.
+     *
+     * @author Lukasz Cwik <lcwik@google.com>
+     */
+    public void testRunWhichThrowsExceptionIsNotWrappedInInvocationTargetException()
+        throws Exception
+    {
+      File pom = new File( getBasedir(), "src/test/projects/project15/pom.xml" );
+
+      try
+      {
+          execute( pom, "java" );
+
+          fail( "Expected Exception to be thrown but none was thrown" );
+      }
+      catch ( Throwable e )
+      {
+          assertTrue( e instanceof MojoExecutionException );
+
+          assertTrue( e.getCause() instanceof IOException );
+
+          assertEquals( "expected IOException thrown by test", e.getCause().getMessage() );
+      }
     }
 
     /**

--- a/src/test/java/org/codehaus/mojo/exec/ThrowingMain.java
+++ b/src/test/java/org/codehaus/mojo/exec/ThrowingMain.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.codehaus.mojo.exec;
+
+import java.io.IOException;
+
+/**
+ * Executable used to test applications which exit exceptionally.
+ *
+ * @author Lukasz Cwik <lcwik@google.com>
+ */
+public class ThrowingMain
+{
+    public static void main( String... args )
+        throws Exception
+    {
+        throw new IOException( "expected IOException thrown by test" );
+    }
+}
+

--- a/src/test/projects/project15/pom.xml
+++ b/src/test/projects/project15/pom.xml
@@ -1,0 +1,47 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.cb.maven.plugins.exec</groupId>
+  <artifactId>project8</artifactId>
+  <version>0.1</version>
+  <packaging>jar</packaging>
+  <name>Maven Exec Plugin</name>
+  <inceptionYear>2005</inceptionYear>
+  <licenses>
+    <license>
+      <name>Apache License 2</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Lukasz Cwik</name>
+      <id>lcwik</id>
+      <email>lcwik@google.com</email>
+      <organization>Google Inc.</organization>
+      <organizationUrl>https://www.google.com/about/company/</organizationUrl>
+    </developer>
+  </developers>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <executions>
+           <execution>
+              <phase>test</phase>
+              <goals>
+                 <goal>java</goal>
+              </goals>
+           </execution>
+        </executions>
+        <configuration>
+          <mainClass>org.codehaus.mojo.exec.ThrowingMain</mainClass>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>


### PR DESCRIPTION
Unwrap the InvocationTargetException improving the error message which users get when their application fails.

This removes the boilerplate found in the plugin output which preceeds the users stacktrace:

```
java.lang.reflect.InvocationTargetException
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.codehaus.mojo.exec.ExecJavaMojo$1.run(ExecJavaMojo.java:293)
        at java.lang.Thread.run(Thread.java:745)
... <Users Stack Trace> ...
```

making it just contain the stack trace from the users application.

This also removes `null: InvocationTargetException:` from the plugin output summary:

```
An exception occured while executing the Java class. null: InvocationTargetException: <Message from users exception>
```

thus making it:

```
An exception occured while executing the Java class. <Message from users exception>
```
