### PR TITLE
Fix Java 8 Javadoc errors

### DIFF
--- a/src/main/java/org/codehaus/mojo/exec/AbstractExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/AbstractExecMojo.java
@@ -76,11 +76,13 @@ public abstract class AbstractExecMojo
     /**
      * If provided the ExecutableDependency identifies which of the plugin dependencies contains the executable class.
      * This will have the affect of only including plugin dependencies required by the identified ExecutableDependency.
-     * <p/>
+     *
+     * <p>
      * If includeProjectDependencies is set to <code>true</code>, all of the project dependencies will be included on
      * the executable's classpath. Whether a particular project dependency is a dependency of the identified
      * ExecutableDependency will be irrelevant to its inclusion in the classpath.
-     * 
+     * </p>
+     *
      * @since 1.1-beta-1
      */
     @Parameter

--- a/src/main/java/org/codehaus/mojo/exec/Classpath.java
+++ b/src/main/java/org/codehaus/mojo/exec/Classpath.java
@@ -20,7 +20,7 @@ package org.codehaus.mojo.exec;
  */
 
 /**
- * @author Jerome Lacoste <jerome@coffeebreaks.org>
+ * @author Jerome Lacoste (jerome@coffeebreaks.org)
  */
 public class Classpath extends AbstractPath
 {

--- a/src/main/java/org/codehaus/mojo/exec/ExecJavaMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecJavaMojo.java
@@ -53,7 +53,7 @@ import org.apache.maven.project.artifact.MavenMetadataSource;
 /**
  * Executes the supplied java class in the current VM with the enclosing project's dependencies as classpath.
  * 
- * @author <a href="mailto:kaare.nilsen@gmail.com">Kaare Nilsen</a>, <a href="mailto:dsmiley@mitre.org">David Smiley</a>
+ * @author Kaare Nilsen (kaare.nilsen@gmail.com), David Smiley (dsmiley@mitre.org)
  * @since 1.0
  */
 @Mojo( name = "java", threadSafe = true, requiresDependencyResolution = ResolutionScope.TEST )

--- a/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
@@ -73,7 +73,7 @@ import org.codehaus.plexus.util.cli.StreamConsumer;
 /**
  * A Plugin for executing external programs.
  *
- * @author Jerome Lacoste <jerome@coffeebreaks.org>
+ * @author Jerome Lacoste (jerome@coffeebreaks.org)
  * @version $Id$
  * @since 1.0
  */

--- a/src/main/java/org/codehaus/mojo/exec/Modulepath.java
+++ b/src/main/java/org/codehaus/mojo/exec/Modulepath.java
@@ -20,7 +20,7 @@ package org.codehaus.mojo.exec;
  */
 
 /**
- * @author Jerome Lacoste <jerome@coffeebreaks.org>
+ * @author Jerome Lacoste (jerome@coffeebreaks.org)
  */
 public class Modulepath extends AbstractPath
 {

--- a/src/main/java/org/codehaus/mojo/exec/Property.java
+++ b/src/main/java/org/codehaus/mojo/exec/Property.java
@@ -22,7 +22,7 @@ package org.codehaus.mojo.exec;
 /**
  * Wrapper class for the systemPropery argument type.
  * 
- * @author <a href="mailto:kaare.nilsen@gmail.com">Kaare Nilsen</a>
+ * @author Kaare Nilsen (kaare.nilsen@gmail.com)
  */
 public class Property
 {


### PR DESCRIPTION
Hi, wasn't going to fix the Java 8 javadoc errors. Originally my request was going to be to just fix one tag, a paragraph tag </p> that was appearing in the Eclipse auto complete.

![screenshot_2016-12-10_15-24-02](https://cloud.githubusercontent.com/assets/304786/21070687/93be30fa-beef-11e6-8fbd-6700b44835ce.png)

But was trying to build the project and decided to fix the other Javadoc errors too. The author tags were the majority of the errors. So I used one pattern that was already in the code, by using () instead of <>.

Happy to update the pull request if necessary too. Here's what it looks like after the change by using a SNAPSHOT version in another project, and using the maven-exec-plugin.

![screenshot_2016-12-10_15-34-08](https://cloud.githubusercontent.com/assets/304786/21070797/2e4e7560-bef2-11e6-82e5-bcba6de663ba.png)

Thank you!
Bruno
