### PR TITLE
fix : running modulepath commandline

### DIFF
--- a/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
@@ -460,6 +460,10 @@ public class ExecMojo
             {
                 commandArguments.add( args[i].replace( CLASSPATH_TOKEN, computeClasspathString( null ) ) );
             }
+            else if ( args[i].contains( MODULEPATH_TOKEN ) )
+            {
+                commandArguments.add( args[i].replace( MODULEPATH_TOKEN, computeClasspathString( null ) ) );
+            }
             else
             {
                 commandArguments.add( args[i] );


### PR DESCRIPTION
I've added a simple fix to support resolving the modulepath when using command line arguments.

Would it be interesting if I worked on running the maven exec plugin with both the classpath and the modulepath together ?