### PR TITLE
Do not drop environment variables that contain '=' in their value, or have no value. 

### DIFF
--- a/src/main/java/org/codehaus/mojo/exec/EnvStreamConsumer.java
+++ b/src/main/java/org/codehaus/mojo/exec/EnvStreamConsumer.java
@@ -38,10 +38,10 @@ public class EnvStreamConsumer
                 envs.put( tokens[0], tokens[1] );
             } else {
                 // Don't hide an environment variable with no value e.g. APP_OVERRIDE=
-                if ( line.trim().endsWith("=") )
+                String trimmedLine = line.trim();
+                if ( trimmedLine.endsWith("=") )
                 {
-                    String trimmed = line.trim();
-                    envs.put( trimmed.substring( 0, ( trimmed.length() - 1 ) ), null );
+                    envs.put( trimmedLine.substring( 0, ( trimmedLine.length() - 1 ) ), null );
                 }
                 else
                 {

--- a/src/main/java/org/codehaus/mojo/exec/EnvStreamConsumer.java
+++ b/src/main/java/org/codehaus/mojo/exec/EnvStreamConsumer.java
@@ -37,7 +37,16 @@ public class EnvStreamConsumer
             {
                 envs.put( tokens[0], tokens[1] );
             } else {
-                unparsed.add( line );
+                // Don't hide an environment variable with no value e.g. APP_OVERRIDE=
+                if ( line.trim().endsWith("=") )
+                {
+                    String trimmed = line.trim();
+                    envs.put( trimmed.substring( 0, ( trimmed.length() - 1 ) ), null );
+                }
+                else
+                {
+                    unparsed.add( line );
+                }
             }
         }
         else

--- a/src/main/java/org/codehaus/mojo/exec/EnvStreamConsumer.java
+++ b/src/main/java/org/codehaus/mojo/exec/EnvStreamConsumer.java
@@ -1,6 +1,8 @@
 package org.codehaus.mojo.exec;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.codehaus.plexus.util.StringUtils;
@@ -15,6 +17,8 @@ public class EnvStreamConsumer
 
     private Map<String, String> envs = new HashMap<String, String>();
 
+    private List<String> unparsed = new ArrayList<String>();
+
     private boolean startParsing = false;
 
     public void consumeLine( String line )
@@ -28,10 +32,12 @@ public class EnvStreamConsumer
 
         if ( this.startParsing )
         {
-            String[] tokens = StringUtils.split( line, "=" );
+            String[] tokens = StringUtils.split( line, "=", 2 );
             if ( tokens.length == 2 )
             {
                 envs.put( tokens[0], tokens[1] );
+            } else {
+                unparsed.add( line );
             }
         }
         else
@@ -46,4 +52,8 @@ public class EnvStreamConsumer
         return this.envs;
     }
 
+    public List<String> getUnparsedLines()
+    {
+        return this.unparsed;
+    }
 }

--- a/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
@@ -1171,6 +1171,15 @@ public class ExecMojo
 
             CommandLineUtils.executeCommandLine( cl, stdout, stderr );
 
+            if(!stdout.getUnparsedLines().isEmpty())
+            {
+                getLog().warn( "The following lines could not be parsed into environment variables :" );
+                for ( String line : stdout.getUnparsedLines() )
+                {
+                    getLog().warn( line );
+                }
+            }
+
             results = stdout.getParsedEnv();
         }
         catch ( CommandLineException e )


### PR DESCRIPTION
I noticed whilst doing a little home project that this plugin will not pass environment variables to the java application from a script file if the environment variable in the script file has an '=' character in it. It silently ignores them.

This change will read environment variables that contain '=' characters and add them to the Java application's environment.
It will also include environment variables whose value is empty. 
Finally, it will log a warning for any environment variables that are dropped, though I don't think it would ever happen because the 'env' command will always return 
VAR=VAL
or
VAR=