### PR TITLE
Fix running executableDependency at Unix-like systems

### DIFF
--- a/src/it/execute-dependency/invoker.properties
+++ b/src/it/execute-dependency/invoker.properties
@@ -1,0 +1,5 @@
+invoker.goals = clean test
+
+#invoker.os.family = unix
+invoker.debug = false
+invoker.buildResult = true

--- a/src/it/execute-dependency/pom.xml
+++ b/src/it/execute-dependency/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.codehaus.mojo.exec.it</groupId>
+    <artifactId>parent</artifactId>
+    <version>0.1</version>
+  </parent>
+
+  <artifactId>execute-dependency</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.5.2</version>
+        <executions>
+          <execution>
+            <id>executable</id>
+            <phase>generate-test-resources</phase>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <configuration>
+              <file>${basedir}/src/main/scripts/dependency-script</file>
+              <groupId>${project.groupId}</groupId>
+              <artifactId>${project.artifactId}-bin</artifactId>
+              <version>${project.version}</version>
+              <packaging>cmd</packaging>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>@pom.version@</version>
+        <executions>
+          <execution>
+            <phase>test</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executableDependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>${project.artifactId}-bin</artifactId>
+              </executableDependency>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>${project.artifactId}-bin</artifactId>
+            <version>${project.version}</version>
+            <type>cmd</type>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/execute-dependency/src/main/scripts/dependency-script
+++ b/src/it/execute-dependency/src/main/scripts/dependency-script
@@ -1,0 +1,1 @@
+echo execute dependency test

--- a/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
@@ -233,6 +233,10 @@ public class ExecMojo
             }
 
             executable = findExecutableArtifact().getFile().getAbsolutePath();
+
+            // At Unix-like systems artifacts come to the local Maven repository without "executable" bit set.
+            new File( executable ).setExecutable( true );
+
             getLog().debug( "using executable dependency " + executable);
         }
 


### PR DESCRIPTION
At Unix-like systems Maven installs artifacts to its local repository
without "executable" bit set. So even if the plugin dependency is an
executable binary or script, it fails to run with "permission denied"
error.

The PR makes the executableDependency file executable at Unix-like
OS. At Windows it is a no-op.