### PR TITLE
[MEXEC-GH-128] - <timeout> configuration parameter

### DIFF
--- a/src/it/projects/mexec-gh-128/invoker.properties
+++ b/src/it/projects/mexec-gh-128/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals = clean package
+invoker.buildResult = failure
+invoker.debug = true

--- a/src/it/projects/mexec-gh-128/pom.xml
+++ b/src/it/projects/mexec-gh-128/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.codehaus.mojo.exec.it</groupId>
+    <artifactId>parent</artifactId>
+    <version>0.1</version>
+  </parent>
+
+  <artifactId>mexec-gh-128</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>@pom.version@</version>
+        <executions>
+          <execution>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <timeout>1000</timeout>
+              <executable>${JAVA_HOME}/bin/java</executable>
+              <arguments>
+                <argument>-cp</argument>
+                <argument>target/classes</argument>
+                <argument>Main</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/mexec-gh-128/src/main/java/Main.java
+++ b/src/it/projects/mexec-gh-128/src/main/java/Main.java
@@ -1,0 +1,15 @@
+import java.io.FileWriter;
+import java.io.Writer;
+import java.net.URL;
+
+public class Main
+{
+    public static void main( String[] args ) throws Exception
+    {
+        /*
+         * Intentionally hangs for "very long" time to simulate a completely stuck executable,
+         * but let the time be so short that the IT would break "quickly" in any case.
+         */
+        Thread.sleep( 10000 );
+    }
+}

--- a/src/it/projects/mexec-gh-128/verify.groovy
+++ b/src/it/projects/mexec-gh-128/verify.groovy
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*
+import java.util.*
+
+t = new IntegrationBase()
+
+def buildLog = new File( basedir, "build.log" )
+
+t.checkExistenceAndContentOfAFile(buildLog, [
+  "[ERROR] Timeout. Process runs longer than 1000 ms."
+])


### PR DESCRIPTION
Fixes #128.

A new `<timeout>` configuration parameter (default: 0, which means "none") allows to explicitly terminate a process running for longer that the given time in minutes, and will fail the build.