### PR TITLE
Don't add null to commandArguments

### DIFF
--- a/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
@@ -535,7 +535,7 @@ public class ExecMojo
             {
                 specialArg = (String) argument;
             }
-            else
+            else if ( argument != null )
             {
                 commandArguments.add( (String) argument );
             }


### PR DESCRIPTION
Proposed resolution to #132 , please close if `null` added to `commandArguments` is intended.