### PR TITLE
Empty argument tag should add empty string instead of null

### DIFF
--- a/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
@@ -564,6 +564,10 @@ public class ExecMojo
             {
                 specialArg = (String) argument;
             }
+            else if (argument == null)
+            {
+                commandArguments.add("");
+            }
             else
             {
                 commandArguments.add( (String) argument );

--- a/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
@@ -566,7 +566,7 @@ public class ExecMojo
             }
             else if (argument == null)
             {
-                commandArguments.add("");
+                commandArguments.add( "" );
             }
             else
             {


### PR DESCRIPTION
Created new PR since I could not update the old one (#133, issue #132 ) due to the fork being deleted.

An empty argument tag such as:
```xml
<argument></argument>
```

Now adds an empty string instead of `null` to `String[] args`.