### PR TITLE
Resolves #152 - Adds option to redirect program output of exec:exec to the maven logger.

### DIFF
--- a/src/main/java/org/codehaus/mojo/exec/Invokable.java
+++ b/src/main/java/org/codehaus/mojo/exec/Invokable.java
@@ -1,0 +1,37 @@
+package org.codehaus.mojo.exec;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * A simple Java 7 pseudo-class based on the Java 8 {@code Consumer} class. Can and should be
+ * deleted once this project moves to a minimum execution environment of Java 8+.
+ *
+ * @param <T> - The type of object that will be acted upon.
+ * @since 3.0.0
+ */
+interface Invokable<T> {
+
+    /**
+     * Takes some object and acts upon it.
+     * 
+     * @param object - The object that will be taken
+     */
+    void accept(T object);
+}

--- a/src/main/java/org/codehaus/mojo/exec/LineRedirectOutputStream.java
+++ b/src/main/java/org/codehaus/mojo/exec/LineRedirectOutputStream.java
@@ -1,0 +1,61 @@
+package org.codehaus.mojo.exec;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.OutputStream;
+
+/**
+ * An output stream that captures one line of output at a time, and then
+ * redirects that line to some {@link Invokable} to act upon as it pleases. This
+ * class is not thread safe and expects to have only one active writer consuming
+ * it at any given time.
+ * 
+ * @since 3.0.0
+ */
+class LineRedirectOutputStream extends OutputStream {
+
+    private StringBuilder currentLine = new StringBuilder();
+    private final Invokable<String> linePrinter;
+
+    public LineRedirectOutputStream(Invokable<String> linePrinter) {
+        this.linePrinter = linePrinter;
+    }
+
+    @Override
+    public void write(final int b) {
+        if ((char) b == '\n') {
+            printAndReset();
+            return;
+        }
+        currentLine.append((char) b);
+    }
+
+    @Override
+    public void flush() {
+        if (currentLine.length() > 0) {
+            printAndReset();
+        }
+    }
+
+    private void printAndReset() {
+        linePrinter.accept(currentLine.toString());
+        currentLine = new StringBuilder();
+    }
+}


### PR DESCRIPTION
These changes would add two new options to exec:exec goal:
* *exec.useMavenLogger* - Program standard and error output will be redirected to the Maven logger as Info and Error level logs, respectively. If not enabled the program output is redirected to standard System.out and System.err of the parent Maven process (i.e. the old plugin behavior). NOTE: This option is ignored when `exec.outputFile` is specified.
* *exec.quiet* - When combined with `exec.useMavenLogger=true`, prints all executed program output at debug level instead of the default info level to the Maven logger.

Please see the javadocs in the code for more information.