### PR TITLE
enable to preload common pool

### DIFF
--- a/src/main/java/org/codehaus/mojo/exec/ExecJavaMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecJavaMojo.java
@@ -16,6 +16,9 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.factory.ArtifactFactory;
@@ -67,6 +70,18 @@ public class ExecJavaMojo
      */
     @Parameter( required = true, property = "exec.mainClass" )
     private String mainClass;
+
+
+    /**
+     * Forces the creation of fork join common pool to avoids the threads to be owned by the isolated thread group
+     * and prevent a proper shutdown.
+     * If set to zero the default parallelism is used to precreate all threads,
+     * if negative it is ignored else the value is the one used to create the fork join threads.
+     *
+     * @since 3.0.1
+     */
+    @Parameter( property = "exec.preloadCommonPool", defaultValue = "0" )
+    private int preloadCommonPool;
 
     /**
      * The class arguments.
@@ -234,6 +249,11 @@ public class ExecJavaMojo
             getLog().debug( msg );
         }
 
+        if ( preloadCommonPool >= 0 )
+        {
+            preloadCommonPool();
+        }
+
         IsolatedThreadGroup threadGroup = new IsolatedThreadGroup( mainClass /* name */ );
         Thread bootstrapThread = new Thread( threadGroup, new Runnable()
         {
@@ -336,6 +356,47 @@ public class ExecJavaMojo
         }
 
         registerSourceRoots();
+    }
+
+    private void preloadCommonPool()
+    {
+        try
+        {
+            // ensure common pool exists in the jvm
+            final Class<?> fjp = Thread.currentThread().getContextClassLoader()
+                    .loadClass("java.util.concurrent.ForkJoinPool");
+            final ExecutorService es = ExecutorService.class.cast(
+                    fjp
+                            .getMethod( "commonPool" )
+                            .invoke( null ) );
+            final int max = preloadCommonPool > 0
+                    ? preloadCommonPool :
+                    Integer.class.cast( fjp.getMethod( "getCommonPoolParallelism" ).invoke( null ) );
+            final CountDownLatch preLoad = new CountDownLatch( 1 );
+            for ( int i = 0;
+                  i < max;
+                  i++ )
+            {
+                es.submit(new Runnable() {
+                    @Override
+                    public void run() {
+                        try
+                        {
+                            preLoad.await();
+                        }
+                        catch ( InterruptedException e )
+                        {
+                            Thread.currentThread().interrupt();
+                        }
+                    }
+                });
+            }
+            preLoad.countDown();
+        }
+        catch (final Exception e)
+        {
+            getLog().debug(e.getMessage() + ", skipping commonpool earger init");
+        }
     }
 
     /**


### PR DESCRIPTION
related to https://github.com/mojohaus/exec-maven-plugin/issues/198

Long story short, since exec:java tries to stop new threads, commonPool ones are identified as such if not already created, issue is that if the exec:java uses commonPool, potentially not in the code (thinking to HttpClient which always uses commonPool for part of its tasks), then exec:java will not stop properly until you skip the shutdown cleanup/daemon flags which is not desired. So idea is to enable to preload the common pool and skip these JVM threads.