### PR TITLE
use Temurin JDK

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         java: [8, 11, 16, 17-ea]
-        jdk: [adopt, zulu]
+        jdk: [temurin, zulu]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
https://github.com/actions/setup-java/blob/main/README.md

```
NOTE: Adopt OpenJDK got moved to Eclipse Temurin and
won't be updated anymore. It is highly recommended to
migrate workflows from adopt to temurin to keep receiving
software and security updates.
```

