### PR TITLE
Fixed message: Removed duplicate space

### DIFF
--- a/src/main/java/org/codehaus/mojo/exec/ExecJavaMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecJavaMojo.java
@@ -456,7 +456,7 @@ public class ExecJavaMojo
         }
         if ( !uncooperativeThreads.isEmpty() )
         {
-            getLog().warn( "NOTE: " + uncooperativeThreads.size() + " thread(s) did not finish despite being asked to "
+            getLog().warn( "NOTE: " + uncooperativeThreads.size() + " thread(s) did not finish despite being asked to"
                 + " via interruption. This is not a problem with exec:java, it is a problem with the running code."
                 + " Although not serious, it should be remedied." );
         }


### PR DESCRIPTION
The message contained 2 spaces between `to` and `via`, but should have only one.