### PR TITLE
Revert "Fix (again) redundent -classpath argument issue when using longClasspath"

### DIFF
--- a/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
@@ -675,7 +675,8 @@ public class ExecMojo
 
                 continue;
             }
-            else if ( argument instanceof Classpath )
+
+            if ( argument instanceof Classpath )
             {
                 Classpath specifiedClasspath = (Classpath) argument;
                 commandArguments.add( computeClasspathString( specifiedClasspath ) );


### PR DESCRIPTION
Reverts mojohaus/exec-maven-plugin#228