### PR TITLE
Enforce JAVA_HOME for ITs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -415,6 +415,24 @@
               </repositories>
             </configuration>
           </plugin>
+          <plugin>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>enforce-JAVA_HOME-is-set</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <requireEnvironmentVariable>
+                      <variableName>JAVA_HOME</variableName>
+                    </requireEnvironmentVariable>
+                  </rules>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>


### PR DESCRIPTION
This envvar is explicitly used in ITs, for example
https://github.com/mojohaus/exec-maven-plugin/blob/f75c252394d48e3570c5dbb3d431b274a50f882a/src/it/projects/jigsaw/pom.xml#L29

This causes somehow unfriendly failure delayed up to ITs.
Thus I propose to replace
```
[ERROR] Failed to execute goal org.codehaus.mojo:exec-maven-plugin:3.0.1-SNAPSHOT:exec (default-cli) on project mexec-100: Command execution failed. Cannot run program "${JAVA_HOME}/bin/java"
```
(that one has to check in `target/its/mexec-100/build.log`) with earlier build failure with
```
[WARNING] Rule 0: org.apache.maven.plugins.enforcer.RequireEnvironmentVariable failed with message:
Environment variable "JAVA_HOME" is required for this build.
```