### PR TITLE
Get rid of maven-artifact-transfer from dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,12 +155,6 @@
       <artifactId>commons-exec</artifactId>
       <version>1.3</version>
     </dependency>
-    
-    <dependency>
-      <groupId>org.apache.maven.shared</groupId>
-      <artifactId>maven-artifact-transfer</artifactId>
-      <version>0.13.1</version>
-    </dependency>
 
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
m-artifact-t was only used for dependencies resolving