### PR TITLE
[#389] Add option 'blockSystemExit' to 'java' mojo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,15 @@
       </roles>
       <timezone>Europe/Berlin</timezone>
     </contributor>
+    <contributor>
+      <name>Alexander Kriegisch</name>
+      <email>protected</email>
+      <organization>Scrum-Master.de - Agiles Projektmanagement</organization>
+      <organizationUrl>https://scrum-master.de</organizationUrl>
+      <roles>
+        <role>Feature Contributor</role>
+      </roles>
+    </contributor>
   </contributors>
 
   <licenses>
@@ -336,6 +345,15 @@
       </properties>
     </profile>
     <profile>
+      <id>java17+</id>
+      <activation>
+        <jdk>[17,)</jdk>
+      </activation>
+      <properties>
+        <invoker.security.manager>-Djava.security.manager=allow</invoker.security.manager>
+      </properties>
+    </profile>
+    <profile>
       <id>run-its</id>
       <build>
         <plugins>
@@ -360,6 +378,11 @@
               <scriptVariables>
                 <projectVersion>${project.version}</projectVersion>
               </scriptVariables>
+              <!--
+                Necessary on JDK 17+ for ITs "mexec-gh-389-block-exit-*" to avoid "UnsupportedOperationException:
+                The Security Manager is deprecated and will be removed in a future release". See profile 'java17+'.
+              -->
+              <mavenOpts>${invoker.security.manager}</mavenOpts>
             </configuration>
             <executions>
               <execution>

--- a/src/it/projects/mexec-gh-389-block-exit-non-zero/invoker.properties
+++ b/src/it/projects/mexec-gh-389-block-exit-non-zero/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals = clean process-classes
+invoker.buildResult = failure
+invoker.debug = false

--- a/src/it/projects/mexec-gh-389-block-exit-non-zero/pom.xml
+++ b/src/it/projects/mexec-gh-389-block-exit-non-zero/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.codehaus.mojo.exec.it</groupId>
+    <artifactId>parent</artifactId>
+    <version>0.1</version>
+  </parent>
+
+  <artifactId>mexec-gh-389</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+            <configuration>
+              <mainClass>Main</mainClass>
+              <blockSystemExit>true</blockSystemExit>
+              <systemProperties>
+                <systemProperty>
+                  <key>exitBehaviour</key>
+                  <value>system-exit-error</value>
+                </systemProperty>
+              </systemProperties>
+              <arguments>
+                <argument>one</argument>
+                <argument>two</argument>
+                <argument>three</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/mexec-gh-389-block-exit-non-zero/src/main/java/Main.java
+++ b/src/it/projects/mexec-gh-389-block-exit-non-zero/src/main/java/Main.java
@@ -1,0 +1,19 @@
+import java.util.Arrays;
+
+public class Main
+{
+    public static void main( String[] args )
+    {
+        System.out.println( Arrays.toString( args ) );
+        switch ( System.getProperty( "exitBehaviour", "ok" ) )
+        {
+            case "throw-exception":
+                throw new RuntimeException( "uh-oh" );
+            case "system-exit-ok":
+                System.exit( 0 );
+            case "system-exit-error":
+                System.exit( 123 );
+        }
+        System.out.println( "OK" );
+    }
+}

--- a/src/it/projects/mexec-gh-389-block-exit-non-zero/verify.groovy
+++ b/src/it/projects/mexec-gh-389-block-exit-non-zero/verify.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright MojoHaus and Contributors
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+def buildLogLines = new File( basedir, "build.log" ).readLines()
+
+// Find "System::exit was called" line index
+def infoMessageLineNumber = buildLogLines.indexOf("[INFO] System::exit was called with return code 123")
+assert infoMessageLineNumber > 0
+// Verify that preceding line is program output
+assert buildLogLines[infoMessageLineNumber - 1] == "[one, two, three]"
+// Verify that subsequent lines contain the beginning of the thrown SystemExitException stack trace
+assert buildLogLines[infoMessageLineNumber + 1].startsWith("[WARNING]")
+assert buildLogLines[infoMessageLineNumber + 2].contains("SystemExitException: System::exit was called with return code 123")
+assert buildLogLines[infoMessageLineNumber + 3].contains("SystemExitManager.checkExit (SystemExitManager.java")

--- a/src/it/projects/mexec-gh-389-block-exit-zero/invoker.properties
+++ b/src/it/projects/mexec-gh-389-block-exit-zero/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals = clean process-classes
+invoker.buildResult = success
+invoker.debug = false

--- a/src/it/projects/mexec-gh-389-block-exit-zero/pom.xml
+++ b/src/it/projects/mexec-gh-389-block-exit-zero/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.codehaus.mojo.exec.it</groupId>
+    <artifactId>parent</artifactId>
+    <version>0.1</version>
+  </parent>
+
+  <artifactId>mexec-gh-389</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+            <configuration>
+              <mainClass>Main</mainClass>
+              <blockSystemExit>true</blockSystemExit>
+              <systemProperties>
+                <systemProperty>
+                  <key>exitBehaviour</key>
+                  <value>system-exit-ok</value>
+                </systemProperty>
+              </systemProperties>
+              <arguments>
+                <argument>one</argument>
+                <argument>two</argument>
+                <argument>three</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/mexec-gh-389-block-exit-zero/src/main/java/Main.java
+++ b/src/it/projects/mexec-gh-389-block-exit-zero/src/main/java/Main.java
@@ -1,0 +1,19 @@
+import java.util.Arrays;
+
+public class Main
+{
+    public static void main( String[] args )
+    {
+        System.out.println( Arrays.toString( args ) );
+        switch ( System.getProperty( "exitBehaviour", "ok" ) )
+        {
+            case "throw-exception":
+                throw new RuntimeException( "uh-oh" );
+            case "system-exit-ok":
+                System.exit( 0 );
+            case "system-exit-error":
+                System.exit( 123 );
+        }
+        System.out.println( "OK" );
+    }
+}

--- a/src/it/projects/mexec-gh-389-block-exit-zero/verify.groovy
+++ b/src/it/projects/mexec-gh-389-block-exit-zero/verify.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright MojoHaus and Contributors
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+def buildLogLines = new File( basedir, "build.log" ).readLines()
+
+// Find "System::exit was called" line index
+def infoMessageLineNumber = buildLogLines.indexOf("[INFO] System::exit was called with return code 0")
+assert infoMessageLineNumber > 0
+// Verify that preceding line is program output
+assert buildLogLines[infoMessageLineNumber - 1] == "[one, two, three]"

--- a/src/it/projects/mexec-gh-389-default-permit-exit/invoker.properties
+++ b/src/it/projects/mexec-gh-389-default-permit-exit/invoker.properties
@@ -1,0 +1,4 @@
+invoker.goals = clean process-classes
+# Cannot not check result, because build terminates unexpectedly
+# invoker.buildResult = failure
+invoker.debug = false

--- a/src/it/projects/mexec-gh-389-default-permit-exit/pom.xml
+++ b/src/it/projects/mexec-gh-389-default-permit-exit/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.codehaus.mojo.exec.it</groupId>
+    <artifactId>parent</artifactId>
+    <version>0.1</version>
+  </parent>
+
+  <artifactId>mexec-gh-389</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+            <configuration>
+              <mainClass>Main</mainClass>
+              <!-- This is the default, no need to specify it -->
+              <!--<blockSystemExit>false</blockSystemExit>-->
+              <systemProperties>
+                <systemProperty>
+                  <key>exitBehaviour</key>
+                  <!-- System.exit with any return code will terminate the JVM and the whole Maven process -->
+                  <value>system-exit-ok</value>
+                </systemProperty>
+              </systemProperties>
+              <arguments>
+                <argument>one</argument>
+                <argument>two</argument>
+                <argument>three</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/mexec-gh-389-default-permit-exit/src/main/java/Main.java
+++ b/src/it/projects/mexec-gh-389-default-permit-exit/src/main/java/Main.java
@@ -1,0 +1,19 @@
+import java.util.Arrays;
+
+public class Main
+{
+    public static void main( String[] args )
+    {
+        System.out.println( Arrays.toString( args ) );
+        switch ( System.getProperty( "exitBehaviour", "ok" ) )
+        {
+            case "throw-exception":
+                throw new RuntimeException( "uh-oh" );
+            case "system-exit-ok":
+                System.exit( 0 );
+            case "system-exit-error":
+                System.exit( 123 );
+        }
+        System.out.println( "OK" );
+    }
+}

--- a/src/it/projects/mexec-gh-389-default-permit-exit/verify.groovy
+++ b/src/it/projects/mexec-gh-389-default-permit-exit/verify.groovy
@@ -1,0 +1,21 @@
+/*
+ * Copyright MojoHaus and Contributors
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+def buildLogLines = new File( basedir, "build.log" ).readLines()
+
+// Second-last line is the last line the called program prints before exiting the JVM with System.exit.
+// Last line is "Running post-build script: ...", i.e. we need to disregard it.
+assert buildLogLines[-2] == "[one, two, three]"

--- a/src/main/java/org/codehaus/mojo/exec/SystemExitException.java
+++ b/src/main/java/org/codehaus/mojo/exec/SystemExitException.java
@@ -1,0 +1,38 @@
+package org.codehaus.mojo.exec;
+
+/*
+ * Copyright MojoHaus and Contributors
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Exception to be thrown by {@link SystemExitManager} when {@link System#exit(int)} is called
+ * 
+ * @author Alexander Kriegisch
+ */
+public class SystemExitException extends SecurityException
+{
+    private final int exitCode;
+
+    public SystemExitException( String s, int exitCode )
+    {
+        super( s );
+        this.exitCode = exitCode;
+    }
+
+    public int getExitCode()
+    {
+        return exitCode;
+    }
+}

--- a/src/main/java/org/codehaus/mojo/exec/SystemExitManager.java
+++ b/src/main/java/org/codehaus/mojo/exec/SystemExitManager.java
@@ -1,0 +1,72 @@
+package org.codehaus.mojo.exec;
+
+/*
+ * Copyright MojoHaus and Contributors
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.security.Permission;
+
+/**
+ * A special security manager (SM) passing on permission checks to the original SM it replaces, except for
+ * {@link #checkExit(int)}
+ * 
+ * @author Alexander Kriegisch
+ */
+public class SystemExitManager extends SecurityManager
+{
+    private final SecurityManager originalSecurityManager;
+
+    public SystemExitManager( SecurityManager originalSecurityManager )
+    {
+        this.originalSecurityManager = originalSecurityManager;
+    }
+
+    /**
+     * Always throws a {@link SystemExitException} when {@link System#exit(int)} is called, instead of terminating the
+     * JVM.
+     * <p>
+     * The exception is meant to be handled in the {@code exec:java} goal. On the one hand, this avoids that Java
+     * code called in process can terminate the JVM and the whole Maven build process with it. On the other hand, the
+     * exception handler can also differentiate between exit status 0 (OK) and non-0 (error) by inspecting
+     * {@link SystemExitException#getExitCode()}:
+     * <ul>
+     *     <li>
+     *         Exit status 0 (OK): Just log the fact that {@link System#exit(int)} was called.
+     *     </li>
+     *     <li>
+     *         Exit status non-0 (error): In addition to logging, the exception is also passed on, failing the mojo
+     *         execution as if the called Java code had terminated with an exception instead of trying to terminate the
+     *         JVM with an error code.
+     *     </li>
+     * </ul>
+     * 
+     * @param status the exit status
+     */
+    @Override
+    public void checkExit( int status )
+    {
+        throw new SystemExitException( "System::exit was called with return code " + status, status );
+    }
+
+    @Override
+    public void checkPermission( Permission perm )
+    {
+        if ( originalSecurityManager != null )
+        {
+            originalSecurityManager.checkPermission( perm );
+        }
+    }
+
+}


### PR DESCRIPTION
This new option enables users to stop programs called by `exec:java` from calling `System::exit`, terminating not just the mojo but the whole Maven JVM.

Closes #389.
Relates to #388.