### PR TITLE
[#391] Cope with Thread::stop being unavailable in JDK 20+

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,5 +24,6 @@ jobs:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v3
     with:
+      jdk-matrix: '[ "8", "17", "21" ]'
       ff-maven: "3.9.5"                              # Maven version for fail-fast-build
       maven-matrix: '[ "3.6.3", "3.8.8", "3.9.5" ]'  # Maven versions matrix for verify builds

--- a/src/test/java/org/codehaus/mojo/exec/MainUncooperative.java
+++ b/src/test/java/org/codehaus/mojo/exec/MainUncooperative.java
@@ -9,6 +9,9 @@ public class MainUncooperative
 {
     public static final String SUCCESS = "1(interrupted)(f)2(f)";
 
+    // In JDK 20+, Thread::stop has been removed and just throws an UnsupportedOperationException
+    public static final String INTERRUPTED_BUT_NOT_STOPPED = "1(interrupted)(f)2";
+
     public static void main( String... args )
         throws InterruptedException
     {


### PR DESCRIPTION
In JDK 20+, the long deprecated `Thread.stop()` (since JDK 1.2) has been removed and will throw an `UnsupportedOperationException`. This will be handled gracefully when using option `stopUnresponsiveDaemonThreads`, yielding a log warning ***"Thread.stop() is unavailable in this JRE version, cannot force-stop any threads"*** once and not trying to stop any further threads during the same execution.

Tests and documentation have been adjusted accordingly.

Closes #391.