### PR TITLE
Get some feedback from Maven core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
   </contributors>
 
   <prerequisites>
-    <maven>${mavenVersion}</maven>
+    <maven>${mavenMinVersion}</maven>
   </prerequisites>
 
   <scm>
@@ -122,7 +122,8 @@
   </scm>
 
   <properties>
-    <mavenVersion>3.6.3</mavenVersion>
+    <mavenMinVersion>3.6.3</mavenMinVersion>
+    <mavenVersion>3.9.6</mavenVersion>
     <recommendedJavaBuildVersion>11</recommendedJavaBuildVersion>
     <slf4j.version>1.7.36</slf4j.version>
     <invoker.parallelThreads>1C</invoker.parallelThreads>
@@ -159,8 +160,7 @@
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-util</artifactId>
-      <!-- bound version with used Maven -->
-      <version>1.4.1</version>
+      <version>1.9.18</version>
     </dependency>
 
     <dependency>
@@ -240,6 +240,16 @@
             <detectLinks>false</detectLinks>
             <detectJavaApiLink>false</detectJavaApiLink>
             <detectOfflineLinks>false</detectOfflineLinks>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <proc>none</proc>
+            <compilerArgs>
+              <compilerArg>-Xlint:deprecation</compilerArg>
+            </compilerArgs>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
Detach prerequisite and compile dependencies.

For me, now build speaks. In `src/main/java`:

```
[WARNING] /home/cstamas/Worx/mojohaus/exec-maven-plugin/src/main/java/org/codehaus/mojo/exec/AbstractExecMojo.java:[141,37] getCompileArtifacts() in org.apache.maven.project.MavenProject has been deprecated
[WARNING] /home/cstamas/Worx/mojohaus/exec-maven-plugin/src/main/java/org/codehaus/mojo/exec/AbstractExecMojo.java:[146,37] getTestArtifacts() in org.apache.maven.project.MavenProject has been deprecated
[WARNING] /home/cstamas/Worx/mojohaus/exec-maven-plugin/src/main/java/org/codehaus/mojo/exec/AbstractExecMojo.java:[152,37] getRuntimeArtifacts() in org.apache.maven.project.MavenProject has been deprecated
[WARNING] /home/cstamas/Worx/mojohaus/exec-maven-plugin/src/main/java/org/codehaus/mojo/exec/AbstractExecMojo.java:[157,37] getSystemArtifacts() in org.apache.maven.project.MavenProject has been deprecated
[WARNING] /home/cstamas/Worx/mojohaus/exec-maven-plugin/src/main/java/org/codehaus/mojo/exec/ExecMojo.java:[945,90] ROLE in org.apache.maven.toolchain.ToolchainManager has been deprecated
[WARNING] /home/cstamas/Worx/mojohaus/exec-maven-plugin/src/main/java/org/codehaus/mojo/exec/ExecMojo.java:[945,51] getContainer() in org.apache.maven.execution.MavenSession has been deprecated
[WARNING] /home/cstamas/Worx/mojohaus/exec-maven-plugin/src/main/java/org/codehaus/mojo/exec/ExecJavaMojo.java:[472,31] stop() in java.lang.Thread has been deprecated
```

And in `src/test/java`:

```
[WARNING] /home/cstamas/Worx/mojohaus/exec-maven-plugin/src/test/java/org/codehaus/mojo/exec/ExecJavaMojoTest.java:[336,27] initMocks(java.lang.Object) in org.mockito.MockitoAnnotations has been deprecated
```