### PR TITLE
Enable to exec:java runnables and not only mains with loosely coupled injections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,6 +259,23 @@
 
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <phase>test-compile</phase>
+            <configuration>
+              <parameters>true</parameters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
         <configuration>

--- a/src/site/apt/examples/example-java-runnable.vm
+++ b/src/site/apt/examples/example-java-runnable.vm
@@ -1,0 +1,95 @@
+ ------
+ Use Runnable with exec:java goal
+ ------
+ Romain Manni-Bucau
+ ------
+ 2022-11-14
+ ------
+
+ ~~ Copyright 2022 The Codehaus
+ ~~
+ ~~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~~ you may not use this file except in compliance with the License.
+ ~~ You may obtain a copy of the License at
+ ~~
+ ~~      http://www.apache.org/licenses/LICENSE-2.0
+ ~~
+ ~~ Unless required by applicable law or agreed to in writing, software
+ ~~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~~ See the License for the specific language governing permissions and
+ ~~ limitations under the License.
+
+ ~~ NOTE: For help with the syntax of this file, see:
+ ~~ http://maven.apache.org/doxia/references/apt-format.html
+
+
+You can use since version `3.1.2` a `Runnable` instead of providing a main class to `exec:java`:
+
+* pom.xml
+
+-------------------
+<project>
+  ...
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            ...
+            <goals>
+              <goal>java</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <mainClass>com.example.MyRunnableImplementation</mainClass>
+          ...
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+   ...
+</project>
+-------------------
+
+The Runnable can be a plain class but can also get constructor injections:
+
+* `systemProperties`: `Properties`, session system properties 
+* `systemPropertiesUpdater`: `BiConsumer&lt;String, String&gt;`, session system properties update callback (pass the key/value to update, null value means removal of the key) 
+* `userProperties`: `Properties`, session user properties 
+* `userPropertiesUpdater`: `BiConsumer&lt;String, String&gt;`, session user properties update callback (pass the key/value to update, null value means removal of the key) 
+* `projectProperties`: `Properties`, project properties 
+* `projectPropertiesUpdater`: `BiConsumer&lt;String, String&gt;`, project properties update callback (pass the key/value to update, null value means removal of the key) 
+* `highestVersionResolver`: `Function&lt;String, String&gt;`, passing a `groupId:artifactId` you get the latest resolved version from the project repositories.
+
+Lastly you can inject a custom maven component naming the Runnable constructor parameter with its type and replacing dots by underscores.
+If you need to provide a hint you can suffix previous type name by `__hint_$yourhint` (assuming it stays a valid java name).
+This kind of parameter injection must be typed `Object`.
+
+Example:
+
+-------------------
+public class HelloRunnable implements Runnable {
+    private final Function<String, String> versionResolver;
+    private final Properties properties;
+    private final BiConsumer<String, String> updater;
+
+    public HelloRunnable(
+            final Function<String, String> highestVersionResolver,
+            final Properties systemProperties,
+            final BiConsumer<String, String> systemPropertiesUpdater) {
+        this.versionResolver = highestVersionResolver;
+        this.properties = systemProperties;
+        this.updater = systemPropertiesUpdater;
+    }
+
+    public void run() {
+        final String v = properties.getProperty("test.version");
+        updater.accept("hello.runnable.output", v + ": " + (versionResolver != null));
+    }
+}
+-------------------

--- a/src/site/apt/index.apt
+++ b/src/site/apt/index.apt
@@ -72,3 +72,5 @@ Exec Maven Plugin
   * {{{./examples/example-exec-using-executabledependency.html} Using executable binary dependencies instead of local executables}}
 
   * {{{./examples/example-java-project-properties.html} Forward maven system properties to the main}}
+
+  * {{{./examples/example-java-runnable.html} Execute a Runnable instead of a main}}

--- a/src/test/java/org/codehaus/mojo/exec/HelloRunnable.java
+++ b/src/test/java/org/codehaus/mojo/exec/HelloRunnable.java
@@ -1,0 +1,25 @@
+package org.codehaus.mojo.exec;
+
+import java.util.Properties;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+public class HelloRunnable implements Runnable {
+    private final Function<String, String> versionResolver;
+    private final Properties properties;
+    private final BiConsumer<String, String> updater;
+
+    public HelloRunnable(
+            final Function<String, String> highestVersionResolver,
+            final Properties systemProperties,
+            final BiConsumer<String, String> systemPropertiesUpdater) {
+        this.versionResolver = highestVersionResolver;
+        this.properties = systemProperties;
+        this.updater = systemPropertiesUpdater;
+    }
+
+    public void run() {
+        final String v = properties.getProperty("test.version");
+        updater.accept("hello.runnable.output", v + ": " + (versionResolver != null));
+    }
+}

--- a/src/test/projects/project19/pom.xml
+++ b/src/test/projects/project19/pom.xml
@@ -1,0 +1,45 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.cb.maven.plugins.exec</groupId>
+  <artifactId>project18</artifactId>
+  <version>0.1</version>
+  <packaging>jar</packaging>
+  <name>Maven Exec Plugin</name>
+  <inceptionYear>2005</inceptionYear>
+
+  <licenses>
+    <license>
+      <name>Apache License 2</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <properties>
+    <test.name>${project.artifactId} project</test.name>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <executions>
+           <execution>
+              <phase>test</phase>
+              <goals>
+                 <goal>java</goal>
+              </goals>
+           </execution>
+        </executions>
+        <configuration>
+          <mainClass>org.codehaus.mojo.exec.HelloRunnable</mainClass>
+          <additionalClasspathElements>
+            <additionalClasspathElements>../../../../target/test-classes</additionalClasspathElements> <!-- test setup requires it -->
+          </additionalClasspathElements>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>


### PR DESCRIPTION
Goal is to enable to quickly use `exec:java` as an in place mojo replacement without having to bring all maven stack for simple needs.


Sample:

```java
import java.util.Properties;
import java.util.function.BiConsumer;
import java.util.function.Function;

public final class ComputeLatest implements Runnable {
    private final Function<String, String> versionResolver;
    private final Properties properties;
    private final BiConsumer<String, String> updater;

    public ComputeLatest(final Function<String, String> highestVersionResolver,
                         final Properties systemProperties,
                         final BiConsumer<String, String> systemPropertiesUpdater) {
        this.versionResolver = highestVersionResolver;
        this.properties = systemProperties;
        this.updater = systemPropertiesUpdater;
    }

    public void run() {
        final var project = properties.getProperty("env.DEPLOY_PROJECT");
        final String ga = switch (project) {
            case "foo" -> "com.demo.app1:deploy";
            case "bar" -> "com.demo.app2:deploy";
            default -> "";
        };
        if (ga.isBlank()) { // ignore
            return;
        }

        var lastVersion = versionResolver.apply(ga);
        if (!lastVersion.endsWith("-SNAPSHOT")) { // likely local since m2 repo shouldn't get published snapshots
            final var lastDot = lastVersion.lastIndexOf('.') + 1;
            lastVersion = lastVersion.substring(0, lastDot) + (Integer.parseInt(lastVersion.substring(lastDot)) + 1) + "-snapshot";
        }
        updater.accept(ga.replace('.', '_').replace(':', '_') + ".latest", lastVersion);
    }
}
```

then use `com_demo_app1_deploy.latest` in any placeholder friendly downstream plugin.
