### PR TITLE
Do not get UPPERCASE env vars

### DIFF
--- a/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
@@ -478,7 +478,13 @@ public class ExecMojo extends AbstractExecMojo {
     private Map<String, String> handleSystemEnvVariables() throws MojoExecutionException {
 
         Map<String, String> enviro = new HashMap<>();
-        Properties systemEnvVars = CommandLineUtils.getSystemEnvVars();
+
+        // Avoid creating env vars that differ only in case on Windows.
+        // https://github.com/mojohaus/exec-maven-plugin/issues/328
+        // It is not enough to avoid duplicates; we must preserve the case found in the "natural" environment.
+        // https://developercommunity.visualstudio.com/t/Build-Error:-MSB6001-in-Maven-Build/10527486?sort=newest
+        Properties systemEnvVars = CommandLineUtils.getSystemEnvVars(true);
+
         for (Map.Entry<?, ?> entry : systemEnvVars.entrySet()) {
             enviro.put((String) entry.getKey(), (String) entry.getValue());
         }

--- a/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
@@ -480,7 +480,7 @@ public class ExecMojo extends AbstractExecMojo {
         // https://github.com/mojohaus/exec-maven-plugin/issues/328
         // It is not enough to avoid duplicates; we must preserve the case found in the "natural" environment.
         // https://developercommunity.visualstudio.com/t/Build-Error:-MSB6001-in-Maven-Build/10527486?sort=newest
-        Map<String, String> enviro = System.getenv();
+        Map<String, String> enviro = new HashMap<>(System.getenv());
         if (environmentVariables != null) {
             enviro.putAll(environmentVariables);
         }

--- a/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
@@ -36,7 +36,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Consumer;

--- a/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
@@ -476,19 +476,11 @@ public class ExecMojo extends AbstractExecMojo {
     }
 
     private Map<String, String> handleSystemEnvVariables() throws MojoExecutionException {
-
-        Map<String, String> enviro = new HashMap<>();
-
         // Avoid creating env vars that differ only in case on Windows.
         // https://github.com/mojohaus/exec-maven-plugin/issues/328
         // It is not enough to avoid duplicates; we must preserve the case found in the "natural" environment.
         // https://developercommunity.visualstudio.com/t/Build-Error:-MSB6001-in-Maven-Build/10527486?sort=newest
-        Properties systemEnvVars = CommandLineUtils.getSystemEnvVars(true);
-
-        for (Map.Entry<?, ?> entry : systemEnvVars.entrySet()) {
-            enviro.put((String) entry.getKey(), (String) entry.getValue());
-        }
-
+        Map<String, String> enviro = System.getenv();
         if (environmentVariables != null) {
             enviro.putAll(environmentVariables);
         }


### PR DESCRIPTION
We hit  [this issue](https://github.com/mojohaus/exec-maven-plugin/issues/328 ) when we updated MSBuild to latest VS2022.
The problem original appears to be simply that maven-exec-plugin was adding both
`EnvironmentVariable`
and its twin that differs only by case
`ENVIRONMENTVARIABLE`
which was indeed a problem.  However, simply removing the duplicates didn't work, because MSBuild is "special".  Apparently, if you have an env var like `OneDrive` and maven-exec-plugin turns that into ONEDRIVE for the launched process environment block, MSBuild somehow finds the original env var definitions (in the registry?) and attempts to add them.  It doesn't detect the duplicate that differs only in case until it is too late and it errors out as described in [this MS bug report]( https://developercommunity.visualstudio.com/t/Build-Error:-MSB6001-in-Maven-Build/10527486?sort=newest)
The answer is trivially simple -- don't UPPERCASE the env vars 