### PR TITLE
fix: NPE because declared MavenSession field hides field of superclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This is the [exec-maven-plugin](http://www.mojohaus.org/exec-maven-plugin/).
 [![Maven Central](https://img.shields.io/maven-central/v/org.codehaus.mojo/exec-maven-plugin.svg?label=Maven%20Central)](https://search.maven.org/artifact/org.codehaus.mojo/exec-maven-plugin)
 [![GitHub CI](https://github.com/mojohaus/exec-maven-plugin/actions/workflows/maven.yml/badge.svg)](https://github.com/mojohaus/exec-maven-plugin/actions/workflows/maven.yml)
 
+## Running integration tests
+
+Execute `mvn -P run-its clean verify`
+
 ## Releasing
 
 * Make sure `gpg-agent` is running.

--- a/src/it/projects/mexec-439/invoker.properties
+++ b/src/it/projects/mexec-439/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = clean test

--- a/src/it/projects/mexec-439/pom.xml
+++ b/src/it/projects/mexec-439/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+
+   <parent>
+      <groupId>org.codehaus.mojo.exec.it</groupId>
+      <artifactId>parent</artifactId>
+      <version>0.1</version>
+   </parent>
+
+   <artifactId>mexec-439</artifactId>
+   <version>0.0.1-SNAPSHOT</version>
+   <packaging>pom</packaging>
+
+   <build>
+      <plugins>
+         <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>@project.version@</version>
+            <executions>
+               <execution>
+                  <phase>test</phase>
+                  <goals>
+                     <goal>exec</goal>
+                  </goals>
+                  <configuration>
+                     <includePluginDependencies>true</includePluginDependencies>
+                     <executableDependency>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                     </executableDependency>
+                     <executable>java</executable>
+                     <arguments>
+                        <argument>-classpath</argument>
+                        <classpath />
+                        <argument>org.junit.runner.JUnitCore</argument>
+                     </arguments>
+                  </configuration>
+               </execution>
+            </executions>
+            <dependencies>
+               <dependency>
+                  <groupId>junit</groupId>
+                  <artifactId>junit</artifactId>
+                  <version>4.13.2</version>
+               </dependency>
+            </dependencies>
+         </plugin>
+      </plugins>
+   </build>
+
+</project>

--- a/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
@@ -285,12 +285,6 @@ public class ExecMojo extends AbstractExecMojo {
     private File environmentScript = null;
 
     /**
-     * The current build session instance. This is used for toolchain manager API calls.
-     */
-    @Parameter(defaultValue = "${session}", readonly = true)
-    private MavenSession session;
-
-    /**
      * Exit codes to be resolved as successful execution for non-compliant applications (applications not returning 0
      * for success).
      *
@@ -430,8 +424,9 @@ public class ExecMojo extends AbstractExecMojo {
                     // output as a log prefix, to enable easy tracing of program output when intermixed with other
                     // Maven log output. NOTE: The accept(..) methods are running in PumpStreamHandler thread,
                     // which is why we capture the thread name prefix here.
-                    final String logPrefix =
-                            session.isParallel() ? "[" + Thread.currentThread().getName() + "] " : "";
+                    final String logPrefix = getSession().isParallel()
+                            ? "[" + Thread.currentThread().getName() + "] "
+                            : "";
                     Consumer<String> mavenOutRedirect = logMessage -> {
                         if (quietLogs) {
                             getLog().debug(logPrefix + logMessage);
@@ -942,6 +937,7 @@ public class ExecMojo extends AbstractExecMojo {
 
     private Toolchain getToolchain() {
         // session and toolchainManager can be null in tests ...
+        MavenSession session = getSession();
         if (session != null && toolchainManager != null) {
             return toolchainManager.getToolchainFromBuildContext(toolchain, session);
         }


### PR DESCRIPTION
The exec goal plugin fails an NPE in the latest 3.4.0 release. The reason is that after the code changes of https://github.com/mojohaus/exec-maven-plugin/pull/432 AbstractExecMojo and ExecMojo declare an injectable `MavenSession session` resulting in one being not populated by Mavens DI.

This PR fixes the issue by removing the redundant `session` field from the ExecMojo.

The issue does not seem to be reproducible in the integration tests, so I cannot provide a new test case.

Stacktrace:
```py
java.lang.NullPointerException: Cannot invoke "org.apache.maven.execution.MavenSession.getRepositorySession()" because the return value of "org.codehaus.mojo.exec.AbstractExecMojo.getSession()" is null
    at org.codehaus.mojo.exec.AbstractExecMojo.resolveExecutableDependencies (AbstractExecMojo.java:346)
    at org.codehaus.mojo.exec.AbstractExecMojo.determineRelevantPluginDependencies (AbstractExecMojo.java:319)
    at org.codehaus.mojo.exec.ExecMojo.computePath (ExecMojo.java:702)
    at org.codehaus.mojo.exec.ExecMojo.computeClasspathString (ExecMojo.java:676)
    at org.codehaus.mojo.exec.ExecMojo.handleArguments (ExecMojo.java:605)
    at org.codehaus.mojo.exec.ExecMojo.execute (ExecMojo.java:391)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:126)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:328)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:316)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:212)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:174)
    at org.apache.maven.lifecycle.internal.MojoExecutor.access$000 (MojoExecutor.java:75)
    at org.apache.maven.lifecycle.internal.MojoExecutor$1.run (MojoExecutor.java:162)
    at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute (DefaultMojosExecutionStrategy.java:39)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:159)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:105)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:73)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:53)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:118)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:261)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:173)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:101)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:903)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:280)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:203)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:77)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:568)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:255)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:201)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:361)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:314)
```