### PR TITLE
Use Maven4 enabled with GH Action

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,6 +24,4 @@ jobs:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v4
     with:
-      ff-maven: "3.9.7"                                     # Maven version for fail-fast-build
-      maven-matrix: '[ "3.6.3", "3.9.7", "4.0.0-beta-3" ]'  # Maven versions matrix for verify builds
-      matrix-exclude: '[ {"jdk": "8", "maven": "4.0.0-beta-3"} ]'
+      maven4-enabled: true


### PR DESCRIPTION
Instead of define Maven 4 in build we can use new option for shared action