### PR TITLE
Add ClassLoader support for ASM ClassWriter

### DIFF
--- a/src/it/projects/mexec-gh-389-block-exit-non-zero/verify.groovy
+++ b/src/it/projects/mexec-gh-389-block-exit-non-zero/verify.groovy
@@ -17,7 +17,7 @@
 def buildLogLines = new File( basedir, "build.log" ).readLines()
 
 // Find "System::exit was called" line index
-def infoMessageLineNumber = buildLogLines.indexOf("[INFO] System::exit was called with return code 123")
+def infoMessageLineNumber = buildLogLines.indexOf("[ERROR] System::exit was called with return code 123")
 assert infoMessageLineNumber > 0
 // Verify that preceding line is program output
 assert buildLogLines[infoMessageLineNumber - 1].contains("[one, two, three]")

--- a/src/it/projects/mexec-gh-389-block-exit-write-classloder/dbchangelog-4.31.xsd
+++ b/src/it/projects/mexec-gh-389-block-exit-write-classloder/dbchangelog-4.31.xsd
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://www.liquibase.org/xml/ns/dbchangelog"
+            xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+            elementFormDefault="qualified">
+
+</xsd:schema>

--- a/src/it/projects/mexec-gh-389-block-exit-write-classloder/invoker.properties
+++ b/src/it/projects/mexec-gh-389-block-exit-write-classloder/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = package
+invoker.debug = false

--- a/src/it/projects/mexec-gh-389-block-exit-write-classloder/pom.xml
+++ b/src/it/projects/mexec-gh-389-block-exit-write-classloder/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.codehaus.mojo.exec.it</groupId>
+    <artifactId>parent</artifactId>
+    <version>0.1</version>
+  </parent>
+
+  <artifactId>mexec-gh-389</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <description>
+    For bigger and more complicated classes org.objectweb.asm.ClassWriter
+    requires access to classloader where can found classes used in transformed class.
+  </description>
+
+  <properties>
+    <xsd-file>dbchangelog-4.31</xsd-file>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>net.java.dev.msv</groupId>
+      <artifactId>msv-rngconverter</artifactId>
+      <version>2022.7</version>
+    </dependency>
+    <dependency>
+      <groupId>org.relaxng</groupId>
+      <artifactId>trang</artifactId>
+      <version>20241231</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>convert-xsd-to-rng</id>
+            <phase>package</phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+            <configuration>
+              <mainClass>com.sun.msv.writer.relaxng.Driver</mainClass>
+              <commandlineArgs>
+                ${project.basedir}/${xsd-file}.xsd
+                ${project.build.directory}/${xsd-file}.rng
+              </commandlineArgs>
+            </configuration>
+          </execution>
+          <execution>
+            <id>convert-liquibase-rng-to-rnc</id>
+            <phase>package</phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+            <configuration>
+              <mainClass>com.thaiopensource.relaxng.translate.Driver</mainClass>
+              <blockSystemExit>true</blockSystemExit>
+              <arguments>
+                <argument>${project.build.directory}/${xsd-file}.rng</argument>
+                <argument>${project.build.directory}/${xsd-file}.rnc</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/projects/mexec-gh-389-block-exit-write-classloder/verify.groovy
+++ b/src/it/projects/mexec-gh-389-block-exit-write-classloder/verify.groovy
@@ -1,0 +1,22 @@
+/*
+ * Copyright MojoHaus and Contributors
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+def buildLogLines = new File(basedir, "build.log").text
+
+assert buildLogLines.contains("[INFO] System::exit was called with return code 0")
+
+assert new File(basedir,'target/dbchangelog-4.31.rnc').exists()
+assert new File(basedir,'target/dbchangelog-4.31.rng').exists()


### PR DESCRIPTION
For bigger and more complicated classes org.objectweb.asm.ClassWriter requires access to classloader where can found classes used in transformed class.

Also add a warning when a class cannot be transformed.