### PR TITLE
[ExecMojo]Add `getShebang` method to correctly set the command line executable name

### DIFF
--- a/src/it/projects/envscript/src/build/env.sh
+++ b/src/it/projects/envscript/src/build/env.sh
@@ -1,2 +1,2 @@
-MY_ENV_SCRIPT_SET_A_VAR_TO=something
-export MY_ENV_SCRIPT_SET_A_VAR_TO
+#!/bin/sh
+export MY_ENV_SCRIPT_SET_A_VAR_TO=something

--- a/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
@@ -278,9 +278,11 @@ public class ExecMojo extends AbstractExecMojo {
     private Map<String, String> environmentVariables = new HashMap<>();
 
     /**
-     * Environment script to be merged with <i>environmentVariables</i> This script is platform specifics, on Unix its
-     * must be Bourne shell format. Use this feature if you have a need to create environment variable dynamically such
-     * as invoking Visual Studio environment script file
+     * Environment script to be merged with <i>environmentVariables</i>. on Unix-like system if the script
+     * contains a shebang line, the executable filename is read from the shebang line; otherwise,
+     * Bourne shell format is used.
+     * Use this feature if you have a need to create environment variable dynamically such as invoking
+     * Visual Studio environment script file.
      *
      * @since 1.4.0
      */
@@ -1014,7 +1016,7 @@ public class ExecMojo extends AbstractExecMojo {
         }
     }
 
-    private String getShebang(File script) {
+    String getShebang(File script) {
         if (script == null || !script.canRead()) {
             getLog().warn("Cannot read script file " + script);
             return null;

--- a/src/test/java/org/codehaus/mojo/exec/ExecMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/exec/ExecMojoTest.java
@@ -12,7 +12,6 @@ package org.codehaus.mojo.exec;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -360,19 +359,17 @@ public class ExecMojoTest extends AbstractMojoTestCase {
 
     public void testGetShebang() throws Exception {
         ExecMojo execMojo = new ExecMojo();
-        Method method = ExecMojo.class.getDeclaredMethod("getShebang", File.class);
-        method.setAccessible(true);
 
         // without shebang
         File noShebang = Files.createTempFile("noShebang", ".sh").toFile();
         Files.write(noShebang.toPath(), Arrays.asList("echo hello"), StandardCharsets.UTF_8);
-        assertNull(method.invoke(execMojo, noShebang));
+        assertNull(execMojo.getShebang(noShebang));
         noShebang.delete();
 
         // with shebang
         File withShebang = Files.createTempFile("withShebang", ".sh").toFile();
         Files.write(withShebang.toPath(), Arrays.asList("#!/bin/bash -x", "echo hello"), StandardCharsets.UTF_8);
-        assertEquals("/bin/bash -x", method.invoke(execMojo, withShebang));
+        assertEquals("/bin/bash -x", execMojo.getShebang(withShebang));
         withShebang.delete();
 
         // with shebang but no args
@@ -382,7 +379,7 @@ public class ExecMojoTest extends AbstractMojoTestCase {
                 withShebangNoArgs.toPath(),
                 Arrays.asList("#!/usr/bin/env python3", "print('hello')"),
                 StandardCharsets.UTF_8);
-        assertEquals("/usr/bin/env python3", method.invoke(execMojo, withShebangNoArgs));
+        assertEquals("/usr/bin/env python3", execMojo.getShebang(withShebangNoArgs));
         withShebangNoArgs.delete();
     }
 

--- a/src/test/java/org/codehaus/mojo/exec/ExecMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/exec/ExecMojoTest.java
@@ -12,6 +12,7 @@ package org.codehaus.mojo.exec;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -355,5 +356,83 @@ public class ExecMojoTest extends AbstractMojoTestCase {
             result += (result.length() == 0 ? "" : " ") + arg;
         }
         return result;
+    }
+
+    public void testGetShebang() throws Exception {
+        ExecMojo execMojo = new ExecMojo();
+        Method method = ExecMojo.class.getDeclaredMethod("getShebang", File.class);
+        method.setAccessible(true);
+
+        // without shebang
+        File noShebang = Files.createTempFile("noShebang", ".sh").toFile();
+        Files.write(noShebang.toPath(), Arrays.asList("echo hello"), StandardCharsets.UTF_8);
+        assertNull(method.invoke(execMojo, noShebang));
+        noShebang.delete();
+
+        // with shebang
+        File withShebang = Files.createTempFile("withShebang", ".sh").toFile();
+        Files.write(withShebang.toPath(), Arrays.asList("#!/bin/bash -x", "echo hello"), StandardCharsets.UTF_8);
+        assertEquals("/bin/bash -x", method.invoke(execMojo, withShebang));
+        withShebang.delete();
+
+        // with shebang but no args
+        File withShebangNoArgs =
+                Files.createTempFile("withShebangNoArgs", ".sh").toFile();
+        Files.write(
+                withShebangNoArgs.toPath(),
+                Arrays.asList("#!/usr/bin/env python3", "print('hello')"),
+                StandardCharsets.UTF_8);
+        assertEquals("/usr/bin/env python3", method.invoke(execMojo, withShebangNoArgs));
+        withShebangNoArgs.delete();
+    }
+
+    public void testCreateEnvWrapperFile() throws Exception {
+        ExecMojo execMojo = new ExecMojo();
+
+        // without shebang
+        File envScript = Files.createTempFile("envScript", ".sh").toFile();
+        Files.write(envScript.toPath(), Arrays.asList("export TEST_VAR=test_value"), StandardCharsets.UTF_8);
+        File wrapper = execMojo.createEnvWrapperFile(envScript);
+        List<String> lines = Files.readAllLines(wrapper.toPath(), StandardCharsets.UTF_8);
+
+        if (OS.isFamilyWindows()) {
+            assertEquals("@echo off", lines.get(0));
+            assertTrue(lines.get(1).startsWith("call \""));
+            assertTrue(lines.get(1).endsWith(envScript.getCanonicalPath() + "\""));
+            assertEquals("echo " + EnvStreamConsumer.START_PARSING_INDICATOR, lines.get(2));
+            assertEquals("set", lines.get(3));
+        } else {
+            assertEquals("#!/bin/sh", lines.get(0));
+            assertEquals(". " + envScript.getCanonicalPath(), lines.get(1));
+            assertEquals("echo " + EnvStreamConsumer.START_PARSING_INDICATOR, lines.get(2));
+            assertEquals("env", lines.get(3));
+        }
+        wrapper.delete();
+        envScript.delete();
+
+        // with shebang
+        File envScriptWithShebang =
+                Files.createTempFile("envScriptWithShebang", ".sh").toFile();
+        Files.write(
+                envScriptWithShebang.toPath(),
+                Arrays.asList("#!/bin/bash", "export TEST_VAR=test_value"),
+                StandardCharsets.UTF_8);
+        File wrapper2 = execMojo.createEnvWrapperFile(envScriptWithShebang);
+        List<String> lines2 = Files.readAllLines(wrapper2.toPath(), StandardCharsets.UTF_8);
+
+        if (OS.isFamilyWindows()) {
+            assertEquals("@echo off", lines2.get(0));
+            assertTrue(lines2.get(1).startsWith("call \""));
+            assertTrue(lines2.get(1).endsWith(envScriptWithShebang.getCanonicalPath() + "\""));
+            assertEquals("echo " + EnvStreamConsumer.START_PARSING_INDICATOR, lines2.get(2));
+            assertEquals("set", lines2.get(3));
+        } else {
+            assertEquals("#!/bin/bash", lines2.get(0));
+            assertEquals(". " + envScriptWithShebang.getCanonicalPath(), lines2.get(1));
+            assertEquals("echo " + EnvStreamConsumer.START_PARSING_INDICATOR, lines2.get(2));
+            assertEquals("env", lines2.get(3));
+        }
+        wrapper2.delete();
+        envScriptWithShebang.delete();
     }
 }


### PR DESCRIPTION
This PR will extract executable name from shebang and correctly set the command-line parameters