### PR TITLE
fix inheritIo option

### DIFF
--- a/src/main/java/org/codehaus/mojo/exec/ExtendedExecutor.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExtendedExecutor.java
@@ -41,7 +41,7 @@ public class ExtendedExecutor extends DefaultExecutor {
     public ExtendedExecutor(boolean inheritIo) {
         this.inheritIo = inheritIo;
     }
-    
+
     @Override
     protected Process launch(CommandLine command, Map<String, String> env, Path workingDirectory) throws IOException {
         return this.launch(command, env, workingDirectory.toFile());

--- a/src/main/java/org/codehaus/mojo/exec/ExtendedExecutor.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExtendedExecutor.java
@@ -44,7 +44,7 @@ public class ExtendedExecutor extends DefaultExecutor {
     
     @Override
     protected Process launch(CommandLine command, Map<String, String> env, Path workingDirectory) throws IOException {
-    	return this.launch(command, env, workingDirectory.toFile());
+        return this.launch(command, env, workingDirectory.toFile());
     }
 
     @Override

--- a/src/main/java/org/codehaus/mojo/exec/ExtendedExecutor.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExtendedExecutor.java
@@ -21,6 +21,7 @@ package org.codehaus.mojo.exec;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Map;
 
 import org.apache.commons.exec.CommandLine;
@@ -39,6 +40,11 @@ public class ExtendedExecutor extends DefaultExecutor {
 
     public ExtendedExecutor(boolean inheritIo) {
         this.inheritIo = inheritIo;
+    }
+    
+    @Override
+    protected Process launch(CommandLine command, Map<String, String> env, Path workingDirectory) throws IOException {
+    	return this.launch(command, env, workingDirectory.toFile());
     }
 
     @Override


### PR DESCRIPTION
When using inheritIo=true stdin is not passed through. The original "launch" function is never called.