### PR TITLE
Arguments in arguments file

### DIFF
--- a/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
@@ -337,6 +337,12 @@ public class ExecMojo extends AbstractExecMojo {
     private boolean async;
 
     /**
+     * If set to true all arguments will be written to file and then used as arguments file using a '@' when using the exec variant.
+     */
+    @Parameter(property = "exec.argumentsFile", defaultValue = "false")
+    private boolean argumentsFile;
+
+    /**
      * If set to true, the asynchronous child process is destroyed upon JVM shutdown. If set to false, asynchronous
      * child process continues execution after JVM shutdown. Applies only to asynchronous processes; ignored for
      * synchronous processes.
@@ -410,9 +416,14 @@ public class ExecMojo extends AbstractExecMojo {
 
             CommandLine commandLine = getExecutablePath(enviro, workingDirectory);
 
-            String[] args = commandArguments.toArray(new String[commandArguments.size()]);
-
-            commandLine.addArguments(args, false);
+            if (argumentsFile) {
+                Path commandLineArguments = Paths.get("target", "commandLineArguments");
+                Files.write(commandLineArguments, commandArguments);
+                commandLine.addArguments(new String[] {"@" + commandLineArguments.toString()}, false);
+            } else {
+                String[] args = commandArguments.toArray(new String[0]);
+                commandLine.addArguments(args, false);
+            }
 
             Executor exec = new ExtendedExecutor(inheritIo);
             if (this.timeout > 0) {
@@ -923,6 +934,10 @@ public class ExecMojo extends AbstractExecMojo {
     //
     // methods used for tests purposes - allow mocking and simulate automatic setters
     //
+
+    void setArgumentsFile(boolean argumentsFile) {
+        this.argumentsFile = argumentsFile;
+    }
 
     void setExecutable(String executable) {
         this.executable = executable;

--- a/src/test/java/org/codehaus/mojo/exec/ExecMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/exec/ExecMojoTest.java
@@ -339,6 +339,29 @@ class ExecMojoTest {
     }
 
     @Test
+    @InjectMojo(goal = "exec", pom = "src/test/projects/project22/pom.xml")
+    void exec_uses_arguments_as_file(ExecMojo execMojo) throws Exception {
+        // given
+        String testJavaPath;
+
+        testJavaPath = "/path/to/java/home";
+        when(toolchainManager.getToolchainFromBuildContext(any(), eq(session)))
+                .thenReturn(new DummyJdkToolchain(testJavaPath + "/bin/java"));
+
+        // when
+        try {
+            execMojo.execute();
+        } catch (Exception e) {
+            // ignore
+        }
+
+        // then
+        assertTrue(
+                Paths.get("target", "commandLineArguments").toFile().exists(),
+                "commandline arugments file should have been created");
+    }
+
+    @Test
     @InjectMojo(goal = "exec", pom = "src/test/projects/project20/pom.xml")
     @DisabledOnOs(OS.WINDOWS)
     void toolchainJavaHomePropertySetWhenToolchainIsUsed(ExecMojo execMojo) throws Exception {

--- a/src/test/projects/project22/pom.xml
+++ b/src/test/projects/project22/pom.xml
@@ -1,0 +1,57 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.cb.maven.plugins.exec</groupId>
+  <artifactId>project1</artifactId>
+  <version>0.1</version>
+  <packaging>jar</packaging>
+  <name>Maven Exec Plugin</name>
+  <inceptionYear>2005</inceptionYear>
+  <licenses>
+    <license>
+      <name>Apache License 2</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Ivo Limmen</name>
+      <id>ivolimmen</id>
+      <email>ivo@limmen.org</email>
+      <roles>
+        <role>Java Developer</role>
+      </roles>
+      <timezone>+1</timezone>
+    </developer>
+  </developers>
+
+  <build>
+    <!-- for manual tests. Can't be automated in the unit tests as the plugin's not installed. What about integration tests? -->
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <executions>
+           <execution>
+              <phase>test</phase>
+              <goals>
+                 <goal>exec</goal>
+              </goals>
+           </execution>
+        </executions>
+        <configuration>
+          <executable>java</executable>
+          <argumentsFile>true</argumentsFile>
+          <arguments>
+            <argument>-Dproject.env1=value1</argument>
+            <argument>-classpath</argument>
+            <classpath/>
+            <argument>org.codehaus.mojo.exec.test1.Test</argument>
+          </arguments>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/test/projects/project22/src/main/java/org/codehaus/mojo/exec/test1/Test.java
+++ b/src/test/projects/project22/src/main/java/org/codehaus/mojo/exec/test1/Test.java
@@ -1,0 +1,7 @@
+package org.codehaus.mojo.exec.test1;
+
+public class Test
+{
+    public static void main( String[] args ) throws Exception { 
+    }
+}


### PR DESCRIPTION
My work required me to move to Windows. As it turns out Windows can not handle a command line with more than 8Kb in the cmd. In the terminal they can handle 32Kb. As it turns out my application uses 36Kb so I can not use Maven Exec.

Since Java 11 it is possible to put all arguments in a single file and use that to start the application.

For example:
File called: `args`
```
--add-opens
java.base/java.lang=ALL-UNNAMED
example.app.Main
```
You can then start it with:
`java @args`

I modified the plugin to accept an argument called `argumentsFile`, only meant to be using along side the exec goal, that will rewrite the arugments to a file `target/commandLineArguments` and replace the arguments with `@target/commandLineArguments`.