### PR TITLE
Handle `%modulepath` token

### DIFF
--- a/src/it/projects/modulepath-from-cli/invoker.properties
+++ b/src/it/projects/modulepath-from-cli/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals.1 = -X clean compile exec:exec \
+  -Dexec.args='-p %modulepath -m mcli.boot/org.mojohaus.mcli.Main'
+invoker.java.version = 9+

--- a/src/it/projects/modulepath-from-cli/pom.xml
+++ b/src/it/projects/modulepath-from-cli/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.codehaus.mojo.exec.it</groupId>
+    <artifactId>parent</artifactId>
+    <version>0.1</version>
+  </parent>
+
+  <artifactId>modulepath-from-cli</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <release>9</release>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+            <executable>${JAVA_HOME}/bin/java</executable>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>3.0.24</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/projects/modulepath-from-cli/src/main/java/module-info.java
+++ b/src/it/projects/modulepath-from-cli/src/main/java/module-info.java
@@ -1,0 +1,6 @@
+module mcli.boot
+{
+  requires plexus.utils;
+  
+  exports org.mojohaus.mcli;
+}

--- a/src/it/projects/modulepath-from-cli/src/main/java/org/mojohaus/mcli/Main.java
+++ b/src/it/projects/modulepath-from-cli/src/main/java/org/mojohaus/mcli/Main.java
@@ -1,0 +1,9 @@
+package org.mojohaus.mcli;
+
+public class Main
+{
+  public static void main(String[] args)
+  {
+    System.out.println("Hello World from mcli");
+  }
+}

--- a/src/it/projects/modulepath-from-cli/verify.groovy
+++ b/src/it/projects/modulepath-from-cli/verify.groovy
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+File log = new File(basedir, 'build.log')
+
+assert log.exists()
+assert log.text.count('Hello World from mcli') > 0

--- a/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
@@ -574,6 +574,8 @@ public class ExecMojo extends AbstractExecMojo {
                 i += 2;
             } else if (args[i].contains(CLASSPATH_TOKEN)) {
                 commandArguments.add(args[i].replace(CLASSPATH_TOKEN, computeClasspathString(null)));
+            } else if (args[i].contains(MODULEPATH_TOKEN)) {
+                commandArguments.add(args[i].replace(MODULEPATH_TOKEN, computeClasspathString(null)));
             } else {
                 commandArguments.add(args[i]);
             }


### PR DESCRIPTION
Currently build.log (from new IT) contains:
```
[DEBUG] Executing command line: [.../bin/java, -p, %modulepath, -m, mcli.boot/org.mojohaus.mcli.Main]
```
i.e. directly with raw `%modulepath` string.

The second commit replaces the said token.

-----

This is advertised in
https://github.com/mojohaus/exec-maven-plugin/blob/0566fddeb1e18c53aab7b31cdd40d5bf8b4a1e32/src/site/apt/examples/example-exec-for-java-programs.apt.vm#L33
https://github.com/mojohaus/exec-maven-plugin/blob/0566fddeb1e18c53aab7b31cdd40d5bf8b4a1e32/src/site/apt/examples/example-exec-for-java-programs.apt.vm#L40-L43