### PR TITLE
Stop dependabot from updating test fixtures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,9 @@ version: 2
 updates:
   - package-ecosystem: "maven"
     directory: "/"
+    exclude-paths:
+      - "src/it/**"
+      - "src/test/projects/**"
     schedule:
       interval: "daily"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Dependabot bumps fixture poms whose pinned version is the test input; #519-#522 each fail on the exact IT they touch. `src/test/projects` is the same kind of tree and has drawn 17 such PRs of its own. Same fix as mojohaus/license-maven-plugin@c43d4ee0, after which that repo's stream of `src/it` PRs stopped.

Supersedes #519, #520, #521, #522.

*This change was created with AI assistance.*