### PR TITLE
Ignore Maven Resolver >= 2.0 and SLF4J >= 2.0 in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,13 @@ updates:
       - "src/test/projects/**"
     schedule:
       interval: "daily"
+    ignore:
+      # Maven Resolver 2.x targets Maven 4
+      - dependency-name: "org.apache.maven.resolver:*"
+        versions: [">= 2.0"]
+      # SLF4J 2.x requires SLF4JServiceProvider, incompatible with Maven 3 runtime
+      - dependency-name: "org.slf4j:*"
+        versions: [">= 2.0"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

Add Dependabot ignore rules in `.github/dependabot.yml` for:
- `org.apache.maven.resolver:*` (`>= 2.0`, targets Maven 4)
- `org.slf4j:*` (`>= 2.0`, drops `StaticLoggerBinder` required by Maven 3 runtime)